### PR TITLE
feat: support reconciling multiple controllers with label predicate

### DIFF
--- a/glu.go
+++ b/glu.go
@@ -66,7 +66,7 @@ type Pipeline interface {
 
 type System struct {
 	ctx       context.Context
-	conf      *config.Config
+	conf      *Config
 	pipelines map[string]Pipeline
 	schedules []Schedule
 	err       error
@@ -104,16 +104,16 @@ func (s *System) AddPipeline(fn func(context.Context, *Config) (Pipeline, error)
 
 func (s *System) configuration() (_ *Config, err error) {
 	if s.conf != nil {
-		return newConfigSource(s.conf), nil
+		return s.conf, nil
 	}
 
-	s.conf, err = config.ReadFromPath("glu.yaml")
+	conf, err := config.ReadFromPath("glu.yaml")
 	if err != nil {
 		return nil, err
 	}
 
 	var level slog.Level
-	if err := level.UnmarshalText([]byte(s.conf.Log.Level)); err != nil {
+	if err := level.UnmarshalText([]byte(conf.Log.Level)); err != nil {
 		return nil, err
 	}
 
@@ -121,7 +121,9 @@ func (s *System) configuration() (_ *Config, err error) {
 		Level: level,
 	})))
 
-	return newConfigSource(s.conf), nil
+	s.conf = newConfigSource(conf)
+
+	return s.conf, nil
 }
 
 func (s *System) Run() error {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,8 @@
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+github.com/mmcloughlin/avo v0.5.0/go.mod h1:ChHFdoV7ql95Wi7vuq2YT1bwCJqiWdZrQ1im3VujLYM=
+github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=


### PR DESCRIPTION
This updates the reconcile CLI to support reconciling across all controllers in the system with optional label selectors.

```
go run ./... reconcile FLAGS [pipeline] [controller]

FLAGS:

    --all             (reconcile all controllers (ignores labels))
    --label key=value (filter controllers by label key value pair)
```