### PR TITLE
fix(oci): lookup cred using registry not repository

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -21,7 +21,7 @@ func New(reference string, cred *credentials.Credential) (_ *Repository, err err
 	}
 
 	if cred != nil {
-		repo.Client, err = cred.OCIClient(repo.Reference.Repository)
+		repo.Client, err = cred.OCIClient(repo.Reference.Registry)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I was using the wrong parameter here in the lookup.