### PR TITLE
fix: calculate width and spacing based on relative estimated widths

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "description": "Glu UI",
   "source": "src/index.html",
   "scripts": {
-    "start": "parcel",
+    "start": "parcel --no-cache",
     "build": "parcel build",
     "lint": "eslint --fix .",
     "format": "prettier --write ."


### PR DESCRIPTION
I kind of got nerd sniped by this. I wanted to learn more about react flow, so I could make some tweaks.
Then I read the spacing code and wondered about some of the choices.
Then I took a crack at making the spacing content aware (estimated based on content lengths).

Before:
<img width="1332" alt="Screenshot 2024-11-14 at 16 42 16" src="https://github.com/user-attachments/assets/84e3b762-fa9f-4735-acbb-044e1cecbc78">

After:
<img width="1318" alt="Screenshot 2024-11-14 at 16 39 40" src="https://github.com/user-attachments/assets/6fa42335-2c8e-418b-8bf7-594f854d2a94">
