### PR TITLE
refactor: CLI package and triggers

### DIFF
--- a/cmd/experiment/experiment.go
+++ b/cmd/experiment/experiment.go
@@ -12,6 +12,7 @@ import (
 	"github.com/get-glu/glu/pkg/phases"
 	"github.com/get-glu/glu/pkg/src/git"
 	"github.com/get-glu/glu/pkg/src/oci"
+	"github.com/get-glu/glu/pkg/triggers/schedule"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -64,11 +65,13 @@ func run(ctx context.Context) error {
 
 			// return configured pipeline to the system
 			return pipeline, nil
-		}).SchedulePromotion(
-		glu.ScheduleInterval(10*time.Second),
-		glu.ScheduleMatchesLabel("env", "staging"),
-		// alternatively, the phase instance can be target directly with:
-		// glu.ScheduleMatchesPhase(gitStaging),
+		}).AddTrigger(
+		schedule.New(
+			schedule.WithInterval(10*time.Second),
+			schedule.MatchesLabel("env", "staging"),
+			// alternatively, the phase instance can be target directly with:
+			// glu.ScheduleMatchesPhase(gitStaging),
+		),
 	).Run()
 }
 

--- a/config.go
+++ b/config.go
@@ -1,0 +1,195 @@
+package glu
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/get-glu/glu/internal/git"
+	"github.com/get-glu/glu/internal/oci"
+	"github.com/get-glu/glu/pkg/config"
+	"github.com/get-glu/glu/pkg/containers"
+	"github.com/get-glu/glu/pkg/credentials"
+	"github.com/get-glu/glu/pkg/scm/github"
+	srcgit "github.com/get-glu/glu/pkg/src/git"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	giturls "github.com/whilp/git-urls"
+)
+
+// Config is a utility for extracting configured sources by their name
+// derived from glu's conventional configuration format.
+type Config struct {
+	conf  *config.Config
+	creds *credentials.CredentialSource
+
+	cache struct {
+		oci      map[string]*oci.Repository
+		repo     map[string]*git.Repository
+		proposer map[string]srcgit.Proposer
+	}
+}
+
+func newConfigSource(conf *config.Config) *Config {
+	c := &Config{
+		conf:  conf,
+		creds: credentials.New(conf.Credentials),
+	}
+
+	c.cache.oci = map[string]*oci.Repository{}
+	c.cache.repo = map[string]*git.Repository{}
+	c.cache.proposer = map[string]srcgit.Proposer{}
+
+	return c
+}
+
+// GitRepository constructs and configures an instance of a *git.Repository
+// using the name to lookup the relevant configuration.
+// It caches built instances and returns the same instance for subsequent
+// calls with the same name.
+func (c *Config) GitRepository(ctx context.Context, name string) (_ *git.Repository, proposer srcgit.Proposer, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("git %q: %w", name, err)
+		}
+	}()
+
+	// check cache for previously built repository
+	if repo, ok := c.cache.repo[name]; ok {
+		return repo, c.cache.proposer[name], nil
+	}
+
+	conf, ok := c.conf.Sources.Git[name]
+	if !ok {
+		return nil, nil, errors.New("configuration not found")
+	}
+
+	var (
+		method  transport.AuthMethod
+		srcOpts = []containers.Option[git.Repository]{
+			git.WithDefaultBranch(conf.DefaultBranch),
+		}
+	)
+
+	if conf.Path != "" {
+		srcOpts = append(srcOpts, git.WithFilesystemStorage(conf.Path))
+	}
+
+	if conf.Remote != nil {
+		slog.Debug("configuring remote", "remote", conf.Remote.Name)
+
+		srcOpts = append(srcOpts, git.WithRemote(conf.Remote.Name, conf.Remote.URL))
+
+		if conf.Remote.Credential != "" {
+			creds, err := c.creds.Get(conf.Remote.Credential)
+			if err != nil {
+				return nil, nil, fmt.Errorf("repository %q: %w", name, err)
+			}
+
+			method, err = creds.GitAuthentication()
+			if err != nil {
+				return nil, nil, fmt.Errorf("repository %q: %w", name, err)
+			}
+		}
+	}
+
+	if method == nil {
+		method, err = ssh.DefaultAuthBuilder("git")
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	repo, err := git.NewRepository(context.Background(), slog.Default(), append(srcOpts, git.WithAuth(method))...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if conf.Proposals != nil {
+		repoURL, err := giturls.Parse(conf.Remote.URL)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		parts := strings.SplitN(strings.TrimPrefix(repoURL.Path, "/"), "/", 2)
+		if len(parts) < 2 {
+			return nil, nil, fmt.Errorf("unexpected repository URL path: %q", repoURL.Path)
+		}
+
+		var (
+			repoOwner = parts[0]
+			repoName  = strings.TrimSuffix(parts[1], ".git")
+		)
+
+		var proposalsEnabled bool
+		if proposalsEnabled = conf.Proposals.Credential != ""; proposalsEnabled {
+			creds, err := c.creds.Get(conf.Proposals.Credential)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			client, err := creds.GitHubClient(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			proposer = github.New(
+				client,
+				repoOwner,
+				repoName,
+			)
+		}
+
+		slog.Debug("configured scm proposer",
+			slog.String("owner", repoOwner),
+			slog.String("name", repoName),
+			slog.Bool("proposals_enabled", proposalsEnabled),
+		)
+	}
+
+	c.cache.repo[name] = repo
+	c.cache.proposer[name] = proposer
+
+	return repo, proposer, nil
+}
+
+// OCIRepository constructs and configures an instance of a *oci.Repository
+// using the name to lookup the relevant configuration.
+// It caches built instances and returns the same instance for subsequent
+// calls with the same name.
+func (c *Config) OCIRepository(name string) (_ *oci.Repository, err error) {
+	// check cache for previously built repository
+	if repo, ok := c.cache.oci[name]; ok {
+		return repo, nil
+	}
+
+	conf, ok := c.conf.Sources.OCI[name]
+	if !ok {
+		return nil, fmt.Errorf("oci %q: configuration not found", name)
+	}
+
+	var cred *credentials.Credential
+	if conf.Credential != "" {
+		cred, err = c.creds.Get(conf.Credential)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	repo, err := oci.New(conf.Reference, cred)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cache.oci[name] = repo
+
+	return repo, nil
+}
+
+// GetCredential delegates to an underlying credential source
+// built using the same underlying credential configuration.
+func (c *Config) GetCredential(name string) (*credentials.Credential, error) {
+	return c.creds.Get(name)
+}

--- a/pipeline.go
+++ b/pipeline.go
@@ -8,8 +8,10 @@ import (
 	"github.com/get-glu/glu/pkg/core"
 )
 
+// Pipeline is an alias for the core Pipeline interface (see core.Pipeline)
 type Pipeline = core.Pipeline
 
+// Phase is an alias for the core Phase interface (see core.Phase)
 type Phase = core.Phase
 
 type entry[R Resource] struct {
@@ -18,13 +20,14 @@ type entry[R Resource] struct {
 }
 
 // ResourcePipeline is a collection of phases for a given resource type R.
+// It implements the core.Phase interface and is scoped to a single Resource implementation.
 type ResourcePipeline[R Resource] struct {
 	meta  Metadata
 	newFn func() R
 	nodes map[string]entry[R]
 }
 
-// NewPipeline constructs and configures a new instance of Pipeline
+// NewPipeline constructs and configures a new instance of *ResourcePipeline[R]
 func NewPipeline[R Resource](meta Metadata, newFn func() R) *ResourcePipeline[R] {
 	return &ResourcePipeline[R]{
 		meta:  meta,

--- a/pipeline.go
+++ b/pipeline.go
@@ -1,0 +1,109 @@
+package glu
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/get-glu/glu/pkg/containers"
+	"github.com/get-glu/glu/pkg/core"
+)
+
+type Pipeline = core.Pipeline
+
+type Phase = core.Phase
+
+type entry[R Resource] struct {
+	core.ResourcePhase[R]
+	opts core.AddPhaseOptions[R]
+}
+
+// ResourcePipeline is a collection of phases for a given resource type R.
+type ResourcePipeline[R Resource] struct {
+	meta  Metadata
+	newFn func() R
+	nodes map[string]entry[R]
+}
+
+// NewPipeline constructs and configures a new instance of Pipeline
+func NewPipeline[R Resource](meta Metadata, newFn func() R) *ResourcePipeline[R] {
+	return &ResourcePipeline[R]{
+		meta:  meta,
+		newFn: newFn,
+		nodes: map[string]entry[R]{},
+	}
+}
+
+// New calls the functions underlying resource constructor function to get a
+// new default instance of the resource.
+func (p *ResourcePipeline[R]) New() R {
+	return p.newFn()
+}
+
+// Metadata returns the metadata assocated with the Pipelines (name and labels).
+func (p *ResourcePipeline[R]) Metadata() Metadata {
+	return p.meta
+}
+
+// Add will add the provided resource phase to the pipeline along with configuring
+// any dependent promotion source phases if configured to do so.
+func (p *ResourcePipeline[R]) Add(r core.ResourcePhase[R], opts ...containers.Option[core.AddPhaseOptions[R]]) error {
+	add := core.AddPhaseOptions[R]{}
+	containers.ApplyAll(&add, opts...)
+
+	if _, existing := p.nodes[r.Metadata().Name]; existing {
+		return fmt.Errorf("phase %q: %w", r.Metadata().Name, core.ErrAlreadyExists)
+	}
+
+	p.nodes[r.Metadata().Name] = entry[R]{r, add}
+
+	return nil
+}
+
+// PromotedFrom returns the phase which c is configured to promote from (get dependent phase).
+func (p *ResourcePipeline[R]) PromotedFrom(c core.ResourcePhase[R]) (core.ResourcePhase[R], bool) {
+	entry, ok := p.nodes[c.Metadata().Name]
+	if !ok || entry.opts.PromotedFrom == nil {
+		return nil, false
+	}
+
+	return entry.opts.PromotedFrom, true
+}
+
+// PhaseByName returns the Phase (if it exists) with a matching name.
+func (p *ResourcePipeline[R]) PhaseByName(name string) (Phase, error) {
+	entry, ok := p.nodes[name]
+	if !ok {
+		return nil, fmt.Errorf("phase %q: %w", name, core.ErrNotFound)
+	}
+
+	return entry.ResourcePhase, nil
+}
+
+// Phases lists all phases in the pipeline with optional predicates.
+func (p *ResourcePipeline[R]) Phases(opts ...containers.Option[core.PhaseOptions]) iter.Seq[Phase] {
+	var options core.PhaseOptions
+	containers.ApplyAll(&options, opts...)
+
+	return iter.Seq[Phase](func(yield func(Phase) bool) {
+		for _, entry := range p.nodes {
+			if !options.Matches(entry.ResourcePhase) {
+				continue
+			}
+
+			if !yield(entry.ResourcePhase) {
+				break
+			}
+		}
+	})
+}
+
+// Dependencies returns a map of Phase to Phase.
+// This map contains mappings of Phases to their dependent promotion source Phase (if configured).
+func (p *ResourcePipeline[R]) Dependencies() map[Phase]Phase {
+	deps := map[Phase]Phase{}
+	for _, entry := range p.nodes {
+		deps[entry.ResourcePhase] = entry.opts.PromotedFrom
+	}
+
+	return deps
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"iter"
+	"log/slog"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/get-glu/glu/pkg/core"
+)
+
+type System interface {
+	GetPipeline(name string) (core.Pipeline, error)
+	Pipelines() iter.Seq2[string, core.Pipeline]
+}
+
+func Run(ctx context.Context, s System, args ...string) error {
+	switch args[1] {
+	case "inspect":
+		return inspect(ctx, s, args[2:]...)
+	case "promote":
+		return promote(ctx, s, args[2:]...)
+	default:
+		return fmt.Errorf("unexpected command %q (expected one of [inspect promote])", args[1])
+	}
+}
+
+func inspect(ctx context.Context, s System, args ...string) (err error) {
+	wr := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	defer func() {
+		if ferr := wr.Flush(); ferr != nil && err == nil {
+			err = ferr
+		}
+	}()
+
+	if len(args) == 0 {
+		fmt.Fprintln(wr, "NAME")
+		for name := range s.Pipelines() {
+			fmt.Fprintln(wr, name)
+		}
+		return nil
+	}
+
+	pipeline, err := s.GetPipeline(args[0])
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 1 {
+		fmt.Fprintln(wr, "NAME\tDEPENDS_ON")
+		deps := pipeline.Dependencies()
+		for phase := range pipeline.Phases() {
+			dependsName := ""
+			if depends, ok := deps[phase]; ok && depends != nil {
+				dependsName = depends.Metadata().Name
+			}
+
+			fmt.Fprintf(wr, "%s\t%s\n", phase.Metadata().Name, dependsName)
+		}
+		return nil
+	}
+
+	phase, err := pipeline.PhaseByName(args[1])
+	if err != nil {
+		return err
+	}
+
+	inst, err := phase.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	var extraFields [][2]string
+	fields, ok := inst.(fields)
+	if ok {
+		extraFields = fields.PrinterFields()
+	}
+
+	fmt.Fprint(wr, "NAME")
+	for _, field := range extraFields {
+		fmt.Fprintf(wr, "\t%s", field[0])
+	}
+	fmt.Fprintln(wr)
+
+	meta := phase.Metadata()
+	fmt.Fprintf(wr, "%s", meta.Name)
+	for _, field := range extraFields {
+		fmt.Fprintf(wr, "\t%s", field[1])
+	}
+	fmt.Fprintln(wr)
+
+	return nil
+}
+
+type fields interface {
+	PrinterFields() [][2]string
+}
+
+type labels map[string]string
+
+func (l labels) String() string {
+	return "KEY=VALUE"
+}
+
+func (l labels) Set(v string) error {
+	key, value, match := strings.Cut(v, "=")
+	if !match {
+		return fmt.Errorf("value should be in the form key=value (found %q)", v)
+	}
+
+	l[key] = value
+
+	return nil
+}
+
+func promote(ctx context.Context, s System, args ...string) error {
+	var (
+		labels = labels{}
+		all    bool
+		apply  bool
+	)
+
+	set := flag.NewFlagSet("promote", flag.ExitOnError)
+	set.Var(&labels, "label", "selector for filtering phases (format key=value)")
+	set.BoolVar(&apply, "apply", false, "actually run promotions (default dry-run)")
+	set.BoolVar(&all, "all", false, "promote all phases (ignores label filters)")
+	if err := set.Parse(args); err != nil {
+		return err
+	}
+
+	var logArgs []any
+	if !apply {
+		logArgs = append(logArgs, "note", "use --apply for promotion to take effect (dry run)")
+	}
+
+	if all {
+		// ignore labels if the all flag is passed
+		labels = nil
+	}
+
+	for k, v := range labels {
+		logArgs = append(logArgs, k, v)
+	}
+
+	slog.Info("starting promotion", logArgs...)
+
+	if set.NArg() == 0 {
+		if len(labels) == 0 && !all {
+			return errors.New("please pass --all if you want to promote all phases")
+		}
+
+		for _, pipeline := range s.Pipelines() {
+			if err := promoteAllPhases(ctx, pipeline.Phases(core.HasAllLabels(labels)), apply); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	pipeline, err := s.GetPipeline(set.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	phases := pipeline.Phases(core.HasAllLabels(labels))
+	if set.NArg() < 2 {
+		return promoteAllPhases(ctx, phases, apply)
+	}
+
+	phase, err := pipeline.PhaseByName(set.Arg(1))
+	if err != nil {
+		return err
+	}
+
+	if err := promoteAllPhases(ctx, toIter(phase), apply); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func toIter[V any](v ...V) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, vv := range v {
+			if !yield(vv) {
+				break
+			}
+		}
+	}
+}
+
+func promoteAllPhases(ctx context.Context, phases iter.Seq[core.Phase], apply bool) error {
+	for phase := range phases {
+		slog.Info("promoting phase", "phase", phase.Metadata().Name, "dry-run", !apply)
+
+		if apply {
+			if err := phase.Promote(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -24,6 +24,8 @@ type Metadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
+// Pipeline is a collection of phases with potential promotion dependencies
+// relationships between one another.
 type Pipeline interface {
 	Metadata() Metadata
 	PhaseByName(string) (Phase, error)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"errors"
-	"fmt"
 	"iter"
 
 	"github.com/get-glu/glu/pkg/containers"
@@ -20,8 +19,23 @@ var (
 // Metadata contains the unique information used to identify
 // a named resource instance in a particular phase.
 type Metadata struct {
-	Name   string            `json:"name"`
-	Labels map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type Pipeline interface {
+	Metadata() Metadata
+	PhaseByName(string) (Phase, error)
+	Phases(...containers.Option[PhaseOptions]) iter.Seq[Phase]
+	Dependencies() map[Phase]Phase
+}
+
+// Resource is an instance of a resource in a phase.
+// Primarilly, it exposes a Digest method used to produce
+// a hash digest of the resource instances current state.
+type Resource interface {
+	Digest() (string, error)
 }
 
 // Phase is the core interface for resource sourcing and management.
@@ -32,43 +46,15 @@ type Phase interface {
 	Promote(context.Context) error
 }
 
-// Resource is an instance of a resource in a phase.
-// Primarilly, it exposes a Digest method used to produce
-// a hash digest of the resource instances current state.
-type Resource interface {
-	Digest() (string, error)
-}
-
-// Pipeline is a collection of phases for a given resource type R.
-type Pipeline[R Resource] struct {
-	meta  Metadata
-	newFn func() R
-	nodes map[string]entry[R]
-}
-
-type entry[R Resource] struct {
-	ResourcePhase[R]
-	promotesFrom ResourcePhase[R]
-}
-
-// NewPipeline constructs and configures a new instance of Pipeline
-func NewPipeline[R Resource](meta Metadata, newFn func() R) *Pipeline[R] {
-	return &Pipeline[R]{
-		meta:  meta,
-		newFn: newFn,
-		nodes: map[string]entry[R]{},
-	}
-}
-
-// AddOptions are used to configure the addition of a ResourcePhase to a Pipeline
-type AddOptions[R Resource] struct {
-	entry entry[R]
+// AddPhaseOptions are used to configure the addition of a ResourcePhase to a Pipeline
+type AddPhaseOptions[R Resource] struct {
+	PromotedFrom ResourcePhase[R]
 }
 
 // PromotesFrom configures a dependent Phase to promote from for the Phase being added.
-func PromotesFrom[R Resource](c ResourcePhase[R]) containers.Option[AddOptions[R]] {
-	return func(ao *AddOptions[R]) {
-		ao.entry.promotesFrom = c
+func PromotesFrom[R Resource](c ResourcePhase[R]) containers.Option[AddPhaseOptions[R]] {
+	return func(o *AddPhaseOptions[R]) {
+		o.PromotedFrom = c
 	}
 }
 
@@ -78,46 +64,22 @@ type ResourcePhase[R Resource] interface {
 	GetResource(context.Context) (R, error)
 }
 
-// New calls the functions underlying resource constructor function to get a
-// new default instance of the resource.
-func (p *Pipeline[R]) New() R {
-	return p.newFn()
-}
-
-// Metadata returns the metadata assocated with the Pipelines (name and labels).
-func (p *Pipeline[R]) Metadata() Metadata {
-	return p.meta
-}
-
-// Add will add the provided resource phase to the pipeline along with configuring
-// any dependent promotion source phases if configured to do so.
-func (p *Pipeline[R]) Add(r ResourcePhase[R], opts ...containers.Option[AddOptions[R]]) error {
-	add := AddOptions[R]{entry: entry[R]{ResourcePhase: r}}
-	containers.ApplyAll(&add, opts...)
-
-	if _, existing := p.nodes[r.Metadata().Name]; existing {
-		return fmt.Errorf("phase %q: %w", r.Metadata().Name, ErrAlreadyExists)
-	}
-
-	p.nodes[r.Metadata().Name] = add.entry
-
-	return nil
-}
-
-// PromotedFrom returns the phase which c is configured to promote from (get dependent phase).
-func (p *Pipeline[R]) PromotedFrom(c ResourcePhase[R]) (ResourcePhase[R], bool) {
-	dep, ok := p.nodes[c.Metadata().Name]
-	if !ok || dep.promotesFrom == nil {
-		return nil, false
-	}
-
-	return dep.promotesFrom, true
-}
-
 // PhaseOptions scopes a call to get phases from a pipeline.
 type PhaseOptions struct {
 	phase  Phase
 	labels map[string]string
+}
+
+func (p *PhaseOptions) Matches(phase Phase) bool {
+	if p.phase != nil && phase != p.phase {
+		return false
+	}
+
+	if !hasAllLabels(phase, p.labels) {
+		return false
+	}
+
+	return true
 }
 
 // IsPhase causes a call to Phases to list specifically the provided phase p.
@@ -143,49 +105,6 @@ func HasAllLabels(labels map[string]string) containers.Option[PhaseOptions] {
 	return func(co *PhaseOptions) {
 		co.labels = labels
 	}
-}
-
-// PhaseByName returns the Phase (if it exists) with a matching name.
-func (p *Pipeline[R]) PhaseByName(name string) (Phase, error) {
-	entry, ok := p.nodes[name]
-	if !ok {
-		return nil, fmt.Errorf("phase %q: %w", name, ErrNotFound)
-	}
-
-	return entry.ResourcePhase, nil
-}
-
-// Phases lists all phases in the pipeline with optional predicates.
-func (p *Pipeline[R]) Phases(opts ...containers.Option[PhaseOptions]) iter.Seq[Phase] {
-	var options PhaseOptions
-	containers.ApplyAll(&options, opts...)
-
-	return iter.Seq[Phase](func(yield func(Phase) bool) {
-		for _, entry := range p.nodes {
-			if options.phase != nil && entry.ResourcePhase != options.phase {
-				continue
-			}
-
-			if !hasAllLabels(entry.ResourcePhase, options.labels) {
-				continue
-			}
-
-			if !yield(entry.ResourcePhase) {
-				break
-			}
-		}
-	})
-}
-
-// Dependencies returns a map of Phase to Phase.
-// This map contains mappings of Phases to their dependent promotion source Phase (if configured).
-func (p *Pipeline[R]) Dependencies() map[Phase]Phase {
-	deps := map[Phase]Phase{}
-	for _, entry := range p.nodes {
-		deps[entry.ResourcePhase] = entry.promotesFrom
-	}
-
-	return deps
 }
 
 // hasAllLabels returns true if the provided phase has all the supplied labels

--- a/pkg/phases/phases.go
+++ b/pkg/phases/phases.go
@@ -23,7 +23,7 @@ type UpdatableSource[R core.Resource] interface {
 type Pipeline[R core.Resource] interface {
 	New() R
 	Metadata() core.Metadata
-	Add(r core.ResourcePhase[R], opts ...containers.Option[core.AddOptions[R]]) error
+	Add(r core.ResourcePhase[R], opts ...containers.Option[core.AddPhaseOptions[R]]) error
 	PromotedFrom(core.ResourcePhase[R]) (core.ResourcePhase[R], bool)
 }
 
@@ -34,7 +34,7 @@ type Phase[R core.Resource] struct {
 	source   Source[R]
 }
 
-func New[R core.Resource](meta core.Metadata, pipeline Pipeline[R], repo Source[R], opts ...containers.Option[core.AddOptions[R]]) (*Phase[R], error) {
+func New[R core.Resource](meta core.Metadata, pipeline Pipeline[R], repo Source[R], opts ...containers.Option[core.AddPhaseOptions[R]]) (*Phase[R], error) {
 	logger := slog.With("name", meta.Name, "pipeline", pipeline.Metadata().Name)
 	for k, v := range meta.Labels {
 		logger = logger.With(k, v)

--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -1,0 +1,75 @@
+package schedule
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/get-glu/glu"
+	"github.com/get-glu/glu/pkg/containers"
+	"github.com/get-glu/glu/pkg/core"
+)
+
+const defaultScheduleInternal = time.Minute
+
+// Trigger is an implementation of a glu.Trigger which runs promotions
+// on a scheduled interval.
+type Trigger struct {
+	interval time.Duration
+	options  []containers.Option[core.PhaseOptions]
+}
+
+// New creates a scheduled trigger for running automated promotion calls.
+func New(opts ...containers.Option[Trigger]) *Trigger {
+	trigger := &Trigger{
+		interval: defaultScheduleInternal,
+	}
+
+	containers.ApplyAll(trigger, opts...)
+
+	return trigger
+}
+
+// Run starts the scheduled calls of Promote on pipeline phases
+// which match any configured target predicate.
+func (t *Trigger) Run(ctx context.Context, p glu.Pipelines) {
+	slog.Debug("starting promotion schedule", "interval", t.interval)
+
+	ticker := time.NewTicker(t.interval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for _, pipeline := range p.Pipelines() {
+				for phase := range pipeline.Phases(t.options...) {
+					if err := phase.Promote(ctx); err != nil {
+						slog.Error("promoting resource", "name", phase.Metadata().Name, "error", err)
+					}
+				}
+			}
+
+		}
+	}
+}
+
+// WithInterval sets the interval on a schedule
+func WithInterval(d time.Duration) containers.Option[Trigger] {
+	return func(t *Trigger) {
+		t.interval = d
+	}
+}
+
+// MatchesPhase sets a match condition which matches a specific phase
+func MatchesPhase(c core.Phase) containers.Option[Trigger] {
+	return func(t *Trigger) {
+		t.options = append(t.options, core.IsPhase(c))
+	}
+}
+
+// MatchesLabel sets a match condition which matches any phase with the provided label
+func MatchesLabel(k, v string) containers.Option[Trigger] {
+	return func(t *Trigger) {
+		t.options = append(t.options, core.HasLabel(k, v))
+	}
+}

--- a/server.go
+++ b/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/get-glu/glu/pkg/core"
@@ -85,15 +84,6 @@ type phaseResponse struct {
 	Value     interface{}       `json:"value,omitempty"`
 }
 
-// Helper functions
-func (s *Server) getPipelineByName(name string) (Pipeline, error) {
-	pipeline, ok := s.system.pipelines[name]
-	if !ok {
-		return nil, fmt.Errorf("pipeline not found")
-	}
-	return pipeline, nil
-}
-
 func (s *Server) createPhaseResponse(phase core.Phase, dependencies map[core.Phase]core.Phase) phaseResponse {
 	var (
 		dependsOn string
@@ -117,7 +107,7 @@ func (s *Server) createPhaseResponse(phase core.Phase, dependencies map[core.Pha
 	}
 }
 
-func (s *Server) createPipelineResponse(ctx context.Context, pipeline Pipeline) (pipelineResponse, error) {
+func (s *Server) createPipelineResponse(ctx context.Context, pipeline core.Pipeline) (pipelineResponse, error) {
 	dependencies := pipeline.Dependencies()
 	phases := make([]phaseResponse, 0)
 
@@ -173,7 +163,7 @@ func (s *Server) listPipelines(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getPipeline(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	pipeline, err := s.getPipelineByName(chi.URLParam(r, "pipeline"))
+	pipeline, err := s.system.GetPipeline(chi.URLParam(r, "pipeline"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -189,7 +179,7 @@ func (s *Server) getPipeline(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getPhase(w http.ResponseWriter, r *http.Request) {
-	pipeline, err := s.getPipelineByName(chi.URLParam(r, "pipeline"))
+	pipeline, err := s.system.GetPipeline(chi.URLParam(r, "pipeline"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -223,7 +213,7 @@ func (s *Server) getPhase(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) promotePhase(w http.ResponseWriter, r *http.Request) {
-	pipeline, err := s.getPipelineByName(chi.URLParam(r, "pipeline"))
+	pipeline, err := s.system.GetPipeline(chi.URLParam(r, "pipeline"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return


### PR DESCRIPTION
I refactored some things. The only breaking change this time is that schedules are now just one implementation of the new `glu.Trigger` abstraction. This will be the entrypoint for other Trigger types in the future.

This depends on the UI promotion change (just where I started from).

AI Summary:

This pull request introduces several significant changes to the codebase, including the addition of new functionalities, refactoring of existing code, and improvements to the configuration and scheduling mechanisms. The most important changes are summarized below:

### New Functionalities
* Added a new `Config` utility in `config.go` to manage and cache configured sources, such as Git and OCI repositories, using glu's conventional configuration format. This includes methods for constructing and configuring instances of repositories and retrieving credentials.
* Introduced a `Trigger` implementation in `pkg/triggers/schedule/schedule.go` for running promotions on a scheduled interval, with options to set intervals and match conditions based on phases or labels.

### Refactoring
* Refactored the `Pipeline` and `Phase` interfaces in `pkg/core/core.go` to separate the responsibilities of managing phases and their dependencies. This includes moving the `AddPhaseOptions` and related methods to a more modular structure. [[1]](diffhunk://#diff-8bc8da9a84451ef75c133a15c5d79f7ec443ed4b3bed908fcf647706ce144a37R24-R33) [[2]](diffhunk://#diff-8bc8da9a84451ef75c133a15c5d79f7ec443ed4b3bed908fcf647706ce144a37L42-R59) [[3]](diffhunk://#diff-8bc8da9a84451ef75c133a15c5d79f7ec443ed4b3bed908fcf647706ce144a37L81-R84) [[4]](diffhunk://#diff-8bc8da9a84451ef75c133a15c5d79f7ec443ed4b3bed908fcf647706ce144a37L148-L190)
* Updated references to `AddOptions` to `AddPhaseOptions` in `pkg/phases/phases.go` to align with the new structure. [[1]](diffhunk://#diff-0f3d323f627831d3abb74e4e9638f92a68751c3f8560c1955e0e351983ec481eL26-R26) [[2]](diffhunk://#diff-0f3d323f627831d3abb74e4e9638f92a68751c3f8560c1955e0e351983ec481eL37-R37)

### Configuration and Scheduling Improvements
* Modified `cmd/experiment/experiment.go` to replace the `SchedulePromotion` method with the new `AddTrigger` method, utilizing the newly added `schedule` package for scheduling promotions. [[1]](diffhunk://#diff-1c7831425be4dd04d46b1e3009494410b25fc5429b55f1d6779da68b5ab61988R15) [[2]](diffhunk://#diff-1c7831425be4dd04d46b1e3009494410b25fc5429b55f1d6779da68b5ab61988L67-R74)

### CLI Enhancements
* Added a new `cli` package in `pkg/cli/cli.go` to handle command-line interactions, including inspecting and promoting pipelines and phases with support for filtering by labels and performing dry-run promotions.

### Minor Changes
* Added annotations support to the `Metadata` struct in `pkg/core/core.go` to provide additional metadata capabilities.

These changes collectively improve the modularity, configurability, and functionality of the codebase, making it more robust and easier to manage.