### PR TITLE
feat: add gh workflow to publish ui tag on version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - run: npm ci
+      working-directory: ui
+
+    - name: Remove dist entry from .gitignore
+      run: sed -i '/dist/d' ui/.gitignore
+
+    - run: npm run build
+      working-directory: ui
+
+    - name: Add commit, tag and push changes
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "github-actions@users.noreply.github.com"
+
+        git add ./ui
+
+        git commit -am "feat: adding generated distributable assets"
+
+        NEW_TAG=$(echo "${{ github.ref }}" | sed 's#^refs/tags/\(.*\)$#ui/\1#')
+
+        echo "Tagging new version $NEW_TAG"
+
+        git tag $NEW_TAG
+
+        git push origin $NEW_TAG


### PR DESCRIPTION
Im going to just yolo try and get this to work without workflow run triggers.
Mostly because, I would have to write two workflows anyway, to handle passing in tags to the run.
Which ultimately means I dont test a main bit of what I want to be working.