### PR TITLE
feat: expose UI embed as function

### DIFF
--- a/ui/embed.go
+++ b/ui/embed.go
@@ -2,7 +2,18 @@ package ui
 
 import (
 	"embed"
+	"io/fs"
 )
 
-//go:embed dist
-var Assets embed.FS
+//go:embed dist/*
+var ui embed.FS
+
+// FS returns the embedded distribution of the Glu UI.
+func FS() fs.FS {
+	fs, err := fs.Sub(ui, "dist")
+	if err != nil {
+		panic(err)
+	}
+
+	return fs
+}


### PR DESCRIPTION
Primarily, this change supports adding the UI via `glu.WithUI(ui.FS())` on a call to `glu.NewSystem(...)`.

I had to change the code slightly to attempt to pull the UI out of the embed dist folder and return the sub fs.
It panics if it cannot do this, which I think is fine and should only happen on the initialization of your system.