### PR TITLE
refactor: get digest through resource method

### DIFF
--- a/ui/src/components/node.tsx
+++ b/ui/src/components/node.tsx
@@ -64,9 +64,7 @@ const PhaseNode = ({ data }: NodeProps<PhaseNodeType>) => {
         )}
       </div>
 
-      <div className="mt-2 font-mono text-xs text-muted-foreground">
-        {data.value?.digest?.slice(-12)}
-      </div>
+      <div className="mt-2 font-mono text-xs text-muted-foreground">{data.digest?.slice(-12)}</div>
 
       <div className="mt-2 flex w-full flex-col">
         {data.labels &&

--- a/ui/src/components/pipeline.tsx
+++ b/ui/src/components/pipeline.tsx
@@ -153,6 +153,7 @@ function getElements(pipeline: PipelineType): FlowPipeline {
         labels: phase.labels || {},
         depends_on: phase.depends_on,
         source_type: phase.source_type,
+        digest: phase.digest,
         value: phase.value
       },
       extent: 'parent'

--- a/ui/src/types/flow.ts
+++ b/ui/src/types/flow.ts
@@ -18,6 +18,7 @@ type PhaseNodeData = {
   labels?: Record<string, string>;
   depends_on?: string;
   source_type?: string;
+  digest?: string;
   value?: PhaseNodeValue;
 };
 

--- a/ui/src/types/flow.ts
+++ b/ui/src/types/flow.ts
@@ -7,11 +7,6 @@ export interface FlowPipeline {
 
 export type PipelineNode = PhaseNode;
 
-type PhaseNodeValue = {
-  digest: string;
-  [key: string]: unknown;
-};
-
 type PhaseNodeData = {
   pipeline: string;
   name: string;
@@ -19,7 +14,7 @@ type PhaseNodeData = {
   depends_on?: string;
   source_type?: string;
   digest?: string;
-  value?: PhaseNodeValue;
+  value?: Record<string, unknown>;
 };
 
 export type PhaseNode = Node<PhaseNodeData, 'phase'>;

--- a/ui/src/types/pipeline.ts
+++ b/ui/src/types/pipeline.ts
@@ -4,18 +4,13 @@ export interface Pipeline {
   phases: Phase[];
 }
 
-type Resource = {
-  digest: string;
-  [key: string]: unknown;
-};
-
 export interface Phase {
   name: string;
   depends_on?: string;
   source_type?: string;
   digest?: string;
   labels?: Record<string, string>;
-  value?: Resource;
+  value?: Record<string, unknown>;
 }
 
 export interface PipelineGroup {

--- a/ui/src/types/pipeline.ts
+++ b/ui/src/types/pipeline.ts
@@ -13,6 +13,7 @@ export interface Phase {
   name: string;
   depends_on?: string;
   source_type?: string;
+  digest?: string;
   labels?: Record<string, string>;
   value?: Resource;
 }


### PR DESCRIPTION
This changes the way we get the digest for the UI to be through the resource interfaces `Digest()` method instead.
This puts the digest as a more consistent field on the response.
Doing so means that folks dont have to make a field that renders with the name `digest` in order to see this.