### PR TITLE
feat: expose source metadata and add oci image url

### DIFF
--- a/examples/fakedata/main.go
+++ b/examples/fakedata/main.go
@@ -31,8 +31,10 @@ func NewMockSource(typ string) *MockSource {
 	return &MockSource{typ: typ}
 }
 
-func (m *MockSource) Type() string {
-	return m.typ
+func (m *MockSource) Metadata() core.Metadata {
+	return core.Metadata{
+		Name: m.typ,
+	}
 }
 
 func (m *MockSource) View(_ context.Context, _, _ core.Metadata, r *MockResource) error {

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/get-glu/glu/pkg/config"
 	"github.com/get-glu/glu/pkg/credentials"
+	"github.com/get-glu/glu/pkg/src/oci"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/registry/remote"
 )
+
+var _ oci.Resolver = (*Repository)(nil)
 
 type Repository struct {
 	repo *remote.Repository
@@ -32,4 +35,8 @@ func New(reference string, cred *credentials.Credential) (_ *Repository, err err
 
 func (r *Repository) Resolve(ctx context.Context) (v1.Descriptor, error) {
 	return r.repo.Resolve(ctx, r.repo.Reference.ReferenceOrDefault())
+}
+
+func (r *Repository) Reference() string {
+	return r.repo.Reference.String()
 }

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -44,7 +44,7 @@ type Resource interface {
 // These types can be registered on pipelines and can depend upon on another for promotion.
 type Phase interface {
 	Metadata() Metadata
-	SourceType() string
+	Source() Metadata
 	Get(context.Context) (Resource, error)
 	Promote(context.Context) error
 }

--- a/pkg/phases/phases.go
+++ b/pkg/phases/phases.go
@@ -11,7 +11,7 @@ import (
 
 // Source is an interface around storage for resources.
 type Source[R core.Resource] interface {
-	Type() string
+	Metadata() core.Metadata
 	View(_ context.Context, pipeline, phase core.Metadata, _ R) error
 }
 
@@ -59,8 +59,8 @@ func (i *Phase[R]) Metadata() core.Metadata {
 	return i.meta
 }
 
-func (i *Phase[R]) SourceType() string {
-	return i.source.Type()
+func (i *Phase[R]) Source() core.Metadata {
+	return i.source.Metadata()
 }
 
 func (i *Phase[R]) Get(ctx context.Context) (core.Resource, error) {

--- a/pkg/src/git/source.go
+++ b/pkg/src/git/source.go
@@ -54,8 +54,10 @@ type Source[A Resource] struct {
 	proposalOptions ProposalOption
 }
 
-func (*Source[A]) Type() string {
-	return "git"
+func (*Source[A]) Metadata() core.Metadata {
+	return core.Metadata{
+		Name: "git",
+	}
 }
 
 type ProposalOption struct {

--- a/pkg/src/oci/oci.go
+++ b/pkg/src/oci/oci.go
@@ -8,6 +8,8 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+const ANNOTATION_OCI_IMAGE_URL = "dev.getglu.oci.image.url"
+
 var _ phases.Source[Resource] = (*Source[Resource])(nil)
 
 type Resource interface {
@@ -17,6 +19,7 @@ type Resource interface {
 
 type Resolver interface {
 	Resolve(_ context.Context) (v1.Descriptor, error)
+	Reference() string
 }
 
 type Source[R Resource] struct {
@@ -29,8 +32,11 @@ func New[R Resource](resolver Resolver) *Source[R] {
 	}
 }
 
-func (s *Source[R]) Type() string {
-	return "oci"
+func (s *Source[R]) Metadata() core.Metadata {
+	return core.Metadata{
+		Name:        "oci",
+		Annotations: map[string]string{ANNOTATION_OCI_IMAGE_URL: s.resolver.Reference()},
+	}
 }
 
 func (s *Source[R]) View(ctx context.Context, _, _ core.Metadata, r R) error {

--- a/server.go
+++ b/server.go
@@ -92,12 +92,11 @@ type pipelineResponse struct {
 }
 
 type phaseResponse struct {
-	Name       string            `json:"name"`
-	DependsOn  string            `json:"depends_on,omitempty"`
-	SourceType string            `json:"source_type,omitempty"`
-	Digest     string            `json:"digest,omitempty"`
-	Labels     map[string]string `json:"labels,omitempty"`
-	Value      interface{}       `json:"value,omitempty"`
+	Name      string            `json:"name"`
+	DependsOn string            `json:"depends_on,omitempty"`
+	Source    core.Metadata     `json:"source,omitempty"`
+	Digest    string            `json:"digest,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
 }
 
 func (s *Server) createPhaseResponse(ctx context.Context, phase core.Phase, dependencies map[core.Phase]core.Phase) (phaseResponse, error) {
@@ -127,12 +126,11 @@ func (s *Server) createPhaseResponse(ctx context.Context, phase core.Phase, depe
 	}
 
 	return phaseResponse{
-		Name:       phase.Metadata().Name,
-		DependsOn:  dependsOn,
-		Labels:     labels,
-		SourceType: phase.SourceType(),
-		Digest:     digest,
-		Value:      v,
+		Name:      phase.Metadata().Name,
+		DependsOn: dependsOn,
+		Labels:    labels,
+		Source:    phase.Source(),
+		Digest:    digest,
 	}, nil
 }
 

--- a/ui/src/components/node.tsx
+++ b/ui/src/components/node.tsx
@@ -14,10 +14,11 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
+import { ANNOTATION_OCI_IMAGE_URL } from '@/types/metadata';
 
 const PhaseNode = ({ data }: NodeProps<PhaseNodeType>) => {
   const getIcon = () => {
-    switch (data.source_type ?? '') {
+    switch (data.source.name ?? '') {
       case 'oci':
         return <Package className="h-4 w-4" />;
       default:
@@ -64,7 +65,24 @@ const PhaseNode = ({ data }: NodeProps<PhaseNodeType>) => {
         )}
       </div>
 
-      <div className="mt-2 font-mono text-xs text-muted-foreground">{data.digest?.slice(-12)}</div>
+      <div className="mt-2 flex items-center gap-2 text-xs">
+        <span>Digest:</span>
+        <span className="font-mono text-xs text-muted-foreground">{data.digest?.slice(-12)}</span>
+      </div>
+
+      {data.source.annotations?.[ANNOTATION_OCI_IMAGE_URL] && (
+        <div className="mt-2 flex items-center gap-2 text-xs">
+          <span>Image:</span>
+          <a
+            href={`https://${data.source.annotations[ANNOTATION_OCI_IMAGE_URL]}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="truncate font-mono text-xs text-muted-foreground hover:text-primary hover:underline"
+          >
+            {data.source.annotations[ANNOTATION_OCI_IMAGE_URL]}
+          </a>
+        </div>
+      )}
 
       <div className="mt-2 flex w-full flex-col">
         {data.labels &&

--- a/ui/src/components/pipeline.tsx
+++ b/ui/src/components/pipeline.tsx
@@ -152,9 +152,8 @@ function getElements(pipeline: PipelineType): FlowPipeline {
         name: phase.name,
         labels: phase.labels || {},
         depends_on: phase.depends_on,
-        source_type: phase.source_type,
-        digest: phase.digest,
-        value: phase.value
+        source: phase.source,
+        digest: phase.digest
       },
       extent: 'parent'
     };

--- a/ui/src/types/flow.ts
+++ b/ui/src/types/flow.ts
@@ -1,4 +1,5 @@
 import type { Edge, Node } from '@xyflow/react';
+import { Metadata } from './metadata';
 
 export interface FlowPipeline {
   nodes: PipelineNode[];
@@ -12,9 +13,8 @@ type PhaseNodeData = {
   name: string;
   labels?: Record<string, string>;
   depends_on?: string;
-  source_type?: string;
+  source: Metadata;
   digest?: string;
-  value?: Record<string, unknown>;
 };
 
 export type PhaseNode = Node<PhaseNodeData, 'phase'>;

--- a/ui/src/types/metadata.ts
+++ b/ui/src/types/metadata.ts
@@ -1,0 +1,7 @@
+export type Metadata = {
+  name: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+};
+
+export const ANNOTATION_OCI_IMAGE_URL = 'dev.getglu.oci.image.url';

--- a/ui/src/types/pipeline.ts
+++ b/ui/src/types/pipeline.ts
@@ -1,3 +1,5 @@
+import { Metadata } from './metadata';
+
 // Server-side pipeline types
 export interface Pipeline {
   name: string;
@@ -7,10 +9,9 @@ export interface Pipeline {
 export interface Phase {
   name: string;
   depends_on?: string;
-  source_type?: string;
+  source: Metadata;
   digest?: string;
   labels?: Record<string, string>;
-  value?: Record<string, unknown>;
 }
 
 export interface PipelineGroup {


### PR DESCRIPTION
![CleanShot 2024-11-20 at 11 05 03](https://github.com/user-attachments/assets/5023187a-bc15-4c53-b84e-7c9b2e532d57)

UI changes are temporary for now pending refactor to show a single pipeline at a time