### PR TITLE
fix(ui): remove hardcoded api url and setup parcel proxy

### DIFF
--- a/ui/.proxyrc.json
+++ b/ui/.proxyrc.json
@@ -1,0 +1,5 @@
+{
+  "/api": {
+    "target": "http://localhost:8080"
+  }
+}

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -3,7 +3,7 @@ import { Pipeline } from '@/types/pipeline';
 import { System } from '@/types/system';
 
 const api = axios.create({
-  baseURL: 'http://localhost:8080/api/v1'
+  baseURL: '/api/v1'
 });
 
 export const getSystem = async (): Promise<System> => {


### PR DESCRIPTION
This makes it so that the UI in dev mode proxies requests with `/api` to `localhost:8080`.
And then it drops the hardcoded `localhost:8080` from the service type.
This way we can host the UI and API together under different ports.