### PR TITLE
fix(config): add support for additionally reading glu.yml and glu.json

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -35,7 +35,7 @@ This is our entrypoint and wrapper for building a Glu configured application.
 
 ```go
 func main() {
-    glu.NewSystem(context.Background()).Run()
+    glu.NewSystem(context.Background(), glu.Name("mysystem")).Run()
 }
 ```
 

--- a/glu.go
+++ b/glu.go
@@ -148,7 +148,7 @@ func (s *System) configuration() (_ *Config, err error) {
 		return s.conf, nil
 	}
 
-	conf, err := config.ReadFromPath("glu.yaml")
+	conf, err := config.ReadFromFS(os.DirFS("."))
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-github/v64 v64.0.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opencontainers/image-spec v1.1.0
+	github.com/stretchr/testify v1.9.0
 	github.com/whilp/git-urls v1.0.0
 	golang.org/x/crypto v0.29.0
 	golang.org/x/oauth2 v0.24.0
@@ -25,6 +26,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.1-0.20240709150035-ccf4b4329d21 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.2.2 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ func (d *Decoder[C]) Decode(c *C) error {
 	}
 
 	m := map[string]any{}
-	if err := d.enc(data, m); err != nil {
+	if err := d.enc(data, &m); err != nil {
 		return fmt.Errorf("unmarshalling configuration: %w", err)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -222,14 +223,37 @@ func TestConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			path: "testdata/json",
+			expected: &Config{
+				Log: Log{Level: "info"},
+				Sources: Sources{
+					Git: GitRepositories{
+						"custom": &GitRepository{
+							Remote: &Remote{
+								Name:       "origin",
+								URL:        "https://corp-repos/custom",
+								Credential: "vault",
+								Interval:   time.Minute,
+							},
+							Path:          "v1",
+							DefaultBranch: "release-v1",
+						},
+					},
+				},
+				Server: Server{
+					Port:     8080,
+					Host:     "0.0.0.0",
+					Protocol: "http",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
 			c, err := ReadFromFS(os.DirFS(tt.path))
-			if err != nil {
-				t.Errorf("expected no error, got %v", err)
-			}
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.expected, c)
 		})

--- a/pkg/config/testdata/git/custom/glu.yml
+++ b/pkg/config/testdata/git/custom/glu.yml
@@ -1,0 +1,10 @@
+sources:
+  git:
+    custom:
+      remote:
+        name: origin
+        url: https://corp-repos/custom
+        credential: vault
+        interval: 1m
+      path: v1
+      default_branch: release-v1

--- a/pkg/config/testdata/json/glu.json
+++ b/pkg/config/testdata/json/glu.json
@@ -1,0 +1,16 @@
+{
+  "sources": {
+    "git": {
+      "custom": {
+        "remote": {
+          "name": "origin",
+          "url": "https://corp-repos/custom",
+          "credential": "vault",
+          "interval": "1m"
+        },
+        "path": "v1",
+        "default_branch": "release-v1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Even though we stated we support `glu.yml` in the docs, I never actually implemented it.
So I added support for that, and ensured we support `glu.json` too (added a test and fixed an issue where we weren't passing a pointer to the config map).