### PR TITLE
fix(ui): tweak sidebar logo and pipeline selector

### DIFF
--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -23,18 +23,20 @@ import { Check, ChevronsUpDown, BookOpen, Github } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Pipeline } from '@/types/pipeline';
 import { useListPipelinesQuery } from '@/services/api';
+import { useParams } from 'react-router-dom';
 
 export function Sidebar() {
   const navigate = useNavigate();
+  const { pipelineId } = useParams();
   const [open, setOpen] = useState(false);
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(pipelineId);
   const { data: pipelinesData, isLoading } = useListPipelinesQuery();
 
   return (
     <SidebarComponent>
       <SidebarContent className="flex h-full flex-col justify-between">
         <SidebarGroup>
-          <SidebarGroupLabel className="mb-4">
+          <SidebarGroupLabel className="mb-2">
             <Link to="/">
               <div className="flex items-center gap-2">
                 <img src={stu} alt="Stu" className="h-8 w-8" />

--- a/ui/src/components/ui/sidebar.tsx
+++ b/ui/src/components/ui/sidebar.tsx
@@ -404,7 +404,7 @@ const SidebarGroup = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'
       <div
         ref={ref}
         data-sidebar="group"
-        className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
+        className={cn('relative flex w-full min-w-0 flex-col p-2 pt-4', className)}
         {...props}
       />
     );


### PR DESCRIPTION
This pull request includes changes to the `ui/src/components/sidebar.tsx` and `ui/src/components/ui/sidebar.tsx` files to improve the functionality and styling of the sidebar component. 

The header uses p-4 and sidebar logo p-2, pt-4 is added to keep the same space in the top of the page.

Small logic is added to preselect current pipeline if the page is visited by direct link like `http://localhost/#/pipelines/checkout`
