### PR TITLE
feat(triggers/schedule): add MatchName predicate

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -71,6 +71,7 @@ type ResourcePhase[R Resource] interface {
 // PhaseOptions scopes a call to get phases from a pipeline.
 type PhaseOptions struct {
 	phase  Phase
+	name   string
 	labels map[string]string
 }
 
@@ -90,6 +91,13 @@ func (p *PhaseOptions) Matches(phase Phase) bool {
 func IsPhase(p Phase) containers.Option[PhaseOptions] {
 	return func(co *PhaseOptions) {
 		co.phase = p
+	}
+}
+
+// HasLabel causes a call to Phases to list any phase with the matching name.
+func HasName(name string) containers.Option[PhaseOptions] {
+	return func(co *PhaseOptions) {
+		co.name = name
 	}
 }
 

--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -67,6 +67,13 @@ func MatchesPhase(c core.Phase) containers.Option[Trigger] {
 	}
 }
 
+// MatchesName sets a match condition which matches a specific phase name
+func MatchesName(name string) containers.Option[Trigger] {
+	return func(t *Trigger) {
+		t.options = append(t.options, core.HasName(name))
+	}
+}
+
 // MatchesLabel sets a match condition which matches any phase with the provided label
 func MatchesLabel(k, v string) containers.Option[Trigger] {
 	return func(t *Trigger) {


### PR DESCRIPTION
Adding a core list predicate and matching schedule predicate for targeting a phase name `HasName`.

This is similar to `HasLabel` and returns all phases with the same name.
Useful if you consistently name phases the same across pipelines.