### PR TITLE
refactor: replace glu.Config with glu.PipelineBuilder

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -117,8 +117,8 @@ While phases handle the lifecycle of promotion, sources interface with your reso
 
 Currently, Glu has implementations for the following sources:
 
-- OCI
-- Git
+- [OCI](../pkg/src/oci)
+- [Git](../pkg/src/git)
 
 We look to add more in the not-so-distant future. However, these can also be implemented by hand via the following interfaces:
 

--- a/examples/fakedata/main.go
+++ b/examples/fakedata/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/get-glu/glu"
+	"github.com/get-glu/glu/pkg/config"
 	"github.com/get-glu/glu/pkg/core"
 	"github.com/get-glu/glu/pkg/phases"
 )
@@ -43,7 +44,7 @@ func (m *MockSource) View(_ context.Context, _, _ core.Metadata, r *MockResource
 
 func run(ctx context.Context) error {
 	system := glu.NewSystem(ctx, glu.Name("mycorp", glu.Label("team", "ecommerce")))
-	system.AddPipeline(func(ctx context.Context, config *glu.Config) (glu.Pipeline, error) {
+	system.AddPipeline(func(ctx context.Context, config *config.Config) (glu.Pipeline, error) {
 		// Create cloud-controller pipeline
 		ccPipeline := glu.NewPipeline(glu.Name("checkout"), NewMockResource)
 
@@ -99,7 +100,7 @@ func run(ctx context.Context) error {
 		return ccPipeline, nil
 	})
 
-	system.AddPipeline(func(ctx context.Context, config *glu.Config) (glu.Pipeline, error) {
+	system.AddPipeline(func(ctx context.Context, config *config.Config) (glu.Pipeline, error) {
 		// Create frontdoor pipeline
 		fdPipeline := glu.NewPipeline(glu.Name("billing"), NewMockResource)
 

--- a/glu.go
+++ b/glu.go
@@ -66,7 +66,7 @@ func Annotation(k, v string) containers.Option[Metadata] {
 type System struct {
 	ctx       context.Context
 	meta      Metadata
-	conf      *Config
+	conf      *config.Config
 	pipelines map[string]core.Pipeline
 	triggers  []Trigger
 	err       error
@@ -120,7 +120,7 @@ func (s *System) Pipelines() iter.Seq2[string, core.Pipeline] {
 // AddPipeline invokes a pipeline builder function provided by the caller.
 // The function is provided with the systems configuration and (if successful)
 // the system registers the resulting pipeline.
-func (s *System) AddPipeline(fn func(context.Context, *Config) (core.Pipeline, error)) *System {
+func (s *System) AddPipeline(fn func(context.Context, *config.Config) (core.Pipeline, error)) *System {
 	// skip next step if error is not nil
 	if s.err != nil {
 		return s
@@ -143,7 +143,7 @@ func (s *System) AddPipeline(fn func(context.Context, *Config) (core.Pipeline, e
 	return s
 }
 
-func (s *System) configuration() (_ *Config, err error) {
+func (s *System) configuration() (_ *config.Config, err error) {
 	if s.conf != nil {
 		return s.conf, nil
 	}
@@ -161,8 +161,6 @@ func (s *System) configuration() (_ *Config, err error) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: level,
 	})))
-
-	s.conf = newConfigSource(conf)
 
 	return s.conf, nil
 }
@@ -185,7 +183,7 @@ func (s *System) Run() error {
 	}
 
 	var (
-		conf  = s.conf.conf
+		conf  = s.conf
 		group *errgroup.Group
 		srv   = http.Server{
 			Addr:    fmt.Sprintf("%s:%d", conf.Server.Host, conf.Server.Port),


### PR DESCRIPTION
Continuing to seize on the pre release and breakable nature of this project 😂 

This removes the concept of `glu.Config` and replaces it with an optional `glu.PipelineBuilder`.
The builder is where the (now optional) typed resource comes into play.

Previously, we couldn't hang a type parameter off the core system, otherwise, we tie the system to a single type parameter.
Same went for configuration and the pipeline interface at this fidelity.

This made creating a config structure that could simplify configuring a typed Git and OCI source hard to do.
Now, `AddPipeline` takes a `func(context.Context, *config.Config) (Pipeline, error)`.
This is not typed and only has access to the raw config.

The new function `glu.BuilderFunc` returns this function type, but it does so by adapting a function which takes the new `*PiplineBuilder` type.

The two functions previously hung off `*glu.Config`, called `GitRepository` and `OCIRepository` have now morphed into:
```
glu.GitSource(...)
// and
glu.OCISource(...)
```

These two functions depend on this builder (and they continue to use it for caching previouslly built dependencies) and return the actual typed `git.Source[R]` and `oci.Source[R]`.
Each of these functions and types share the core constraint of `glu.Resource`.
However, the Git and OCI ones further constrain it with their respective necessary requirements.

TL;DR this removes the need to know about a sources repository dependency (and removes the need for more type arguments):

https://github.com/get-glu/glu/blob/e3daa16e6d2b57608f8badc0bef1f75550d5be4f/examples/oci-and-git/experiment.go#L22-L37
