### PR TITLE
refactor: simplify system.AddPipeline and introduce builder package

### DIFF
--- a/glu.go
+++ b/glu.go
@@ -120,30 +120,13 @@ func (s *System) Pipelines() iter.Seq2[string, core.Pipeline] {
 // AddPipeline invokes a pipeline builder function provided by the caller.
 // The function is provided with the systems configuration and (if successful)
 // the system registers the resulting pipeline.
-func (s *System) AddPipeline(fn func(context.Context, *Config) (core.Pipeline, error)) *System {
-	// skip next step if error is not nil
-	if s.err != nil {
-		return s
-	}
-
-	config, err := s.configuration()
-	if err != nil {
-		s.err = fmt.Errorf("configuring pipeline: %w", err)
-		return s
-	}
-
-	pipe, err := fn(s.ctx, config)
-	if err != nil {
-		s.err = fmt.Errorf("building pipeline: %w", err)
-		return s
-	}
-
-	s.pipelines[pipe.Metadata().Name] = pipe
+func (s *System) AddPipeline(pipeline core.Pipeline) *System {
+	s.pipelines[pipeline.Metadata().Name] = pipeline
 
 	return s
 }
 
-func (s *System) configuration() (_ *Config, err error) {
+func (s *System) Configuration() (_ *Config, err error) {
 	if s.conf != nil {
 		return s.conf, nil
 	}
@@ -162,7 +145,7 @@ func (s *System) configuration() (_ *Config, err error) {
 		Level: level,
 	})))
 
-	s.conf = newConfigSource(conf)
+	s.conf = newConfigSource(s.ctx, conf)
 
 	return s.conf, nil
 }

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,0 +1,101 @@
+package builder
+
+import (
+	"github.com/get-glu/glu"
+	"github.com/get-glu/glu/pkg/containers"
+	"github.com/get-glu/glu/pkg/core"
+	"github.com/get-glu/glu/pkg/phases"
+	srcgit "github.com/get-glu/glu/pkg/src/git"
+	srcoci "github.com/get-glu/glu/pkg/src/oci"
+)
+
+// SystemBuilder is a utility type for populating systems with type constrained pipelines.
+// It has a number of utilities for simplifying common configuration options used
+// to create types sources and phases within a typed pipeline.
+type SystemBuilder[R glu.Resource] struct {
+	*glu.System
+
+	err error
+}
+
+// New constructs and configures a new system builder.
+func New[R glu.Resource](system *glu.System) *SystemBuilder[R] {
+	return &SystemBuilder[R]{System: system}
+}
+
+type PipelineBuilder[R glu.Resource] interface {
+	Configuration() (*glu.Config, error)
+	// NewPhase constructs a new phase and registers it on the builders resulting pipeline.
+	NewPhase(meta glu.Metadata, source phases.Source[R], _ ...containers.Option[core.AddPhaseOptions[R]]) (*phases.Phase[R], error)
+}
+
+// Run delegates to the underlying system Run method after checking for any
+// previously observed errors.
+func (b *SystemBuilder[R]) Run() error {
+	if b.err != nil {
+		return b.err
+	}
+
+	return b.System.Run()
+}
+
+// BuildPipeline creates a new pipeline and invokes the provided build function with a pipeline builder.
+// It is up to the caller to use this builder in order to create new sources and phases.
+func (b *SystemBuilder[R]) BuildPipeline(meta glu.Metadata, newFunc func() R, build func(builder PipelineBuilder[R]) error) *SystemBuilder[R] {
+	// skip if we previously observed an error
+	if b.err != nil {
+		return b
+	}
+
+	pipeline := glu.NewPipeline(meta, newFunc)
+
+	if err := build(pipelineBuilder[R]{b, pipeline}); err != nil {
+		b.err = err
+		return b
+	}
+
+	b.System.AddPipeline(pipeline)
+
+	return b
+}
+
+type pipelineBuilder[R glu.Resource] struct {
+	*SystemBuilder[R]
+
+	pipeline *glu.ResourcePipeline[R]
+}
+
+// NewPhase constructs a new phase and registers it on the builders resulting pipeline.
+func (p pipelineBuilder[R]) NewPhase(meta glu.Metadata, source phases.Source[R], opts ...containers.Option[core.AddPhaseOptions[R]]) (*phases.Phase[R], error) {
+	return phases.New(meta, p.pipeline, source, opts...)
+}
+
+// GitSource is a convenience function for building a git.Source implementation using a pipeline builder implementation.
+func GitSource[R srcgit.Resource](builder PipelineBuilder[R], name string, opts ...containers.Option[srcgit.Source[R]]) (*srcgit.Source[R], error) {
+	config, err := builder.Configuration()
+	if err != nil {
+		return nil, err
+	}
+
+	repo, proposer, err := config.GitRepository(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return srcgit.NewSource(repo, proposer, opts...), nil
+}
+
+// OCISource  is a convenience function for building an oci.Source implementation using a pipeline builder implementation.
+func OCISource[R srcoci.Resource](builder PipelineBuilder[R], name string, opts ...containers.Option[srcoci.Source[R]]) (*srcoci.Source[R], error) {
+	config, err := builder.Configuration()
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := config.OCIRepository(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return srcoci.New[R](repo), nil
+}


### PR DESCRIPTION
This is a take two for: https://github.com/get-glu/glu/pull/75

The primary goal is to remove the need to have the two-step process:

- build a git / oci repository client
- build a git / oci source

Simply, reducing this down to just building the source by name.
The tricky part is keeping the type parameters from causing problems.
But I have achieved something by introducing a new, opt-in `builder.New()` builder type.
This decorates a system, and provides the same kind of pattern, with more convenient, typed dependency injection.

I think the best thing to look at is the the oci example:
https://github.com/get-glu/glu/commit/312e49c37f860ce8ae5e29e0c459fd18e5f3ac93#diff-fe6b899b22b752013be9ce9f55a5b4db1c0ce69463aee92ee006cd5179c88a1e