### PR TITLE
chore: updates the docs coverpage to remove progressive delivery statement

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -2,7 +2,7 @@
 
 # Glu
 
-> Progressive Delivery That Sticks
+> A Deployment Pipeline Framework That Sticks
 
 - A framework for orchestrating and introspecting delivery pipelines
 - Integrates with directly with Git, OCI and more (to come)


### PR DESCRIPTION
I missed this one.