### PR TITLE
feat(credentials): attempt to support GH app for OCI/packages

### DIFF
--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -139,6 +139,13 @@ func (c *Credential) GitAuthentication() (auth transport.AuthMethod, err error) 
 }
 
 func (c *Credential) OCIClient(registry string) (_ *auth.Client, err error) {
+	if registry == "docker.io" {
+		// it is expected that traffic targeting "docker.io" will be redirected
+		// to "registry-1.docker.io"
+		// reference: https://github.com/moby/moby/blob/v24.0.0-beta.2/registry/config.go#L25-L48
+		registry = "registry-1.docker.io"
+	}
+
 	var creds auth.CredentialFunc
 	switch c.config.Type {
 	case config.CredentialTypeBasic:
@@ -153,6 +160,27 @@ func (c *Credential) OCIClient(registry string) (_ *auth.Client, err error) {
 		}
 
 		creds = credentials.Credential(store)
+	case config.CredentialTypeGitHubApp:
+		transport, err := c.githubInstallationTransport()
+		if err != nil {
+			return nil, err
+		}
+
+		creds = auth.CredentialFunc(func(ctx context.Context, hostport string) (auth.Credential, error) {
+			token, err := transport.Token(context.Background())
+			if err != nil {
+				return auth.EmptyCredential, err
+			}
+
+			if hostport == registry {
+				return auth.Credential{
+					Username: "x-access-token",
+					Password: token,
+				}, nil
+			}
+
+			return auth.EmptyCredential, nil
+		})
 	default:
 		return nil, fmt.Errorf("oci: unxpected credential type: %q", c.config.Type)
 	}


### PR DESCRIPTION
I'm not 💯 certain GitHub App authentication works at all with packages after reading this Discussion:
https://github.com/orgs/community/discussions/24636

But, I thought I would take a stab at it, the way I have effectively done GH app for git pulls is similar to this approach.
I am using the gh installation package transport as my token cache and fetcher.
Then I am setting it as basic auth creds on the OCI pull.
GH expects this for git pull, I can't say if it will work for packages in a similar way.

Going to get this in and give it a try though.