### PR TITLE
feat: support resource annotations

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -40,6 +40,11 @@ type Resource interface {
 	Digest() (string, error)
 }
 
+type ResourceWithAnnotations interface {
+	Resource
+	Annotations() map[string]string
+}
+
 // Phase is the core interface for resource sourcing and management.
 // These types can be registered on pipelines and can depend upon on another for promotion.
 type Phase interface {

--- a/pkg/src/oci/oci.go
+++ b/pkg/src/oci/oci.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/get-glu/glu/pkg/core"
 	"github.com/get-glu/glu/pkg/phases"
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -46,4 +47,27 @@ func (s *Source[R]) View(ctx context.Context, _, _ core.Metadata, r R) error {
 	}
 
 	return r.ReadFromOCIDescriptor(desc)
+}
+
+type BaseResource struct {
+	// ImageName   string // TODO: add this when we have a use case for it
+	ImageDigest digest.Digest
+	annotations map[string]string
+}
+
+func (r *BaseResource) Digest() (string, error) {
+	return r.ImageDigest.Encoded(), nil
+}
+
+func (r *BaseResource) Annotations() map[string]string {
+	return r.annotations
+}
+
+func (r *BaseResource) ReadFromOCIDescriptor(desc v1.Descriptor) error {
+	r.ImageDigest = desc.Digest
+	for k, v := range desc.Annotations {
+		r.annotations[k] = v
+	}
+
+	return nil
 }

--- a/ui/src/components/node-panel.tsx
+++ b/ui/src/components/node-panel.tsx
@@ -28,10 +28,10 @@ export function NodePanel({ node, isExpanded, onToggle }: NodePanelProps) {
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center gap-2">
           {getIcon()}
-          <h2 className="text-lg font-semibold">{node.data.name}</h2>
+          <h2 className="text-lg font-semibold">{node.data.metadata.name}</h2>
           {node.data.depends_on && node.data.depends_on !== '' && (
             <>
-              {node.data.synced ? (
+              {node.data.resource.synced ? (
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -82,19 +82,19 @@ export function NodePanel({ node, isExpanded, onToggle }: NodePanelProps) {
               </div>
               <div className="text-sm">
                 <span className="text-muted-foreground">Digest: </span>
-                <span className="truncate font-mono text-xs">{node.data.digest}</span>
+                <span className="truncate font-mono text-xs">{node.data.resource.digest}</span>
               </div>
             </div>
           </div>
         </div>
 
         <div className="space-y-4 overflow-hidden p-4">
-          {node.data.labels && Object.keys(node.data.labels).length > 0 && (
+          {node.data.metadata.labels && Object.keys(node.data.metadata.labels).length > 0 && (
             <div>
               <h3 className="text-sm font-medium">Labels</h3>
               <div className="mt-2 flex flex-wrap gap-2">
-                {node.data.labels &&
-                  Object.entries(node.data.labels).map(([key, value]) => (
+                {node.data.metadata.labels &&
+                  Object.entries(node.data.metadata.labels).map(([key, value]) => (
                     <Label key={key} labelKey={key} value={value} />
                   ))}
               </div>

--- a/ui/src/components/node.tsx
+++ b/ui/src/components/node.tsx
@@ -17,9 +17,9 @@ import { Label } from './label';
 import { TooltipProvider, TooltipTrigger, TooltipContent, Tooltip } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
 
-const PhaseNode = ({ data }: NodeProps<PhaseNodeType>) => {
+const PhaseNode = ({ data: phase }: NodeProps<PhaseNodeType>) => {
   const getIcon = () => {
-    switch (data.source.name ?? '') {
+    switch (phase.source.name ?? '') {
       case 'oci':
         return <Package className="h-4 w-4" />;
       default:
@@ -32,7 +32,7 @@ const PhaseNode = ({ data }: NodeProps<PhaseNodeType>) => {
   const [promotePhase] = usePromotePhaseMutation();
   const promote = async () => {
     setDialogOpen(false);
-    await promotePhase({ pipeline: data.pipeline, phase: data.name }).unwrap();
+    await promotePhase({ pipeline: phase.pipeline, phase: phase.metadata.name }).unwrap();
     toast.success('Phase promotion scheduled');
   };
 
@@ -43,11 +43,11 @@ const PhaseNode = ({ data }: NodeProps<PhaseNodeType>) => {
       <div className="flex items-center gap-2">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           {getIcon()}
-          <span className="truncate text-sm font-medium">{data.name}</span>
+          <span className="truncate text-sm font-medium">{phase.metadata.name}</span>
         </div>
-        {data.depends_on && data.depends_on !== '' && (
+        {phase.depends_on && phase.depends_on !== '' && (
           <>
-            {data.synced ? (
+            {phase.resource.synced ? (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -79,27 +79,29 @@ const PhaseNode = ({ data }: NodeProps<PhaseNodeType>) => {
 
       <div className="mt-2 flex items-center gap-2 text-xs">
         <span>Digest:</span>
-        <span className="font-mono text-xs text-muted-foreground">{data.digest?.slice(-12)}</span>
+        <span className="font-mono text-xs text-muted-foreground">
+          {phase.resource.digest?.slice(-12)}
+        </span>
       </div>
 
-      {data.source.annotations?.[ANNOTATION_OCI_IMAGE_URL] && (
+      {phase.source.annotations?.[ANNOTATION_OCI_IMAGE_URL] && (
         <div className="mt-2 flex items-center gap-2 text-xs">
           <span>Image:</span>
           <a
-            href={`https://${data.source.annotations[ANNOTATION_OCI_IMAGE_URL]}`}
+            href={`https://${phase.source.annotations[ANNOTATION_OCI_IMAGE_URL]}`}
             target="_blank"
             rel="noopener noreferrer"
             className="truncate font-mono text-xs text-muted-foreground hover:text-primary hover:underline"
           >
-            {data.source.annotations[ANNOTATION_OCI_IMAGE_URL]}
+            {phase.source.annotations[ANNOTATION_OCI_IMAGE_URL]}
           </a>
         </div>
       )}
 
       <div className="mt-2 flex w-full flex-col">
-        {data.labels &&
-          Object.entries(data.labels).length > 0 &&
-          Object.entries(data.labels).map(([key, value]) => (
+        {phase.metadata.labels &&
+          Object.entries(phase.metadata.labels).length > 0 &&
+          Object.entries(phase.metadata.labels).map(([key, value]) => (
             <div key={`${key}-${value}`} className="mb-2 flex">
               <Label labelKey={key} value={value} />
             </div>

--- a/ui/src/components/pipeline.tsx
+++ b/ui/src/components/pipeline.tsx
@@ -142,17 +142,15 @@ function getElements(pipeline: PipelineType): FlowPipeline {
 
   pipeline.phases.forEach((phase) => {
     const node: PhaseNode = {
-      id: phase.name,
+      id: phase.metadata.name,
       type: 'phase',
       position: { x: 0, y: 0 },
       data: {
         pipeline: pipeline.name,
-        name: phase.name,
-        labels: phase.labels || {},
-        depends_on: phase.depends_on,
+        metadata: phase.metadata,
         source: phase.source,
-        digest: phase.digest,
-        synced: phase.synced
+        resource: phase.resource,
+        depends_on: phase.depends_on
       },
       extent: 'parent'
     };
@@ -160,9 +158,9 @@ function getElements(pipeline: PipelineType): FlowPipeline {
 
     if (phase.depends_on) {
       edges.push({
-        id: `edge-${phase.depends_on}-${phase.name}`,
+        id: `edge-${phase.depends_on}-${phase.metadata.name}`,
         source: phase.depends_on,
-        target: phase.name
+        target: phase.metadata.name
       });
     }
   });

--- a/ui/src/types/flow.ts
+++ b/ui/src/types/flow.ts
@@ -1,5 +1,4 @@
 import type { Edge, Node } from '@xyflow/react';
-import { Metadata } from './metadata';
 import { Phase } from './pipeline';
 
 export interface FlowPipeline {

--- a/ui/src/types/flow.ts
+++ b/ui/src/types/flow.ts
@@ -1,5 +1,6 @@
 import type { Edge, Node } from '@xyflow/react';
 import { Metadata } from './metadata';
+import { Phase } from './pipeline';
 
 export interface FlowPipeline {
   nodes: PipelineNode[];
@@ -8,15 +9,10 @@ export interface FlowPipeline {
 
 export type PipelineNode = PhaseNode;
 
-type PhaseNodeData = {
-  pipeline: string;
-  name: string;
-  labels?: Record<string, string>;
-  depends_on?: string;
-  source: Metadata;
-  digest?: string;
-  synced?: boolean;
-};
+type PhaseNodeData = Phase &
+  Record<string, unknown> & {
+    pipeline: string;
+  };
 
 export type PhaseNode = Node<PhaseNodeData, 'phase'>;
 

--- a/ui/src/types/pipeline.ts
+++ b/ui/src/types/pipeline.ts
@@ -1,4 +1,5 @@
 import { Metadata } from './metadata';
+import { Resource } from './resource';
 
 // Server-side pipeline types
 export interface Pipeline {
@@ -7,10 +8,8 @@ export interface Pipeline {
 }
 
 export interface Phase {
-  name: string;
-  depends_on?: string;
+  metadata: Metadata;
   source: Metadata;
-  digest?: string;
-  labels?: Record<string, string>;
-  synced?: boolean;
+  depends_on?: string;
+  resource: Resource;
 }

--- a/ui/src/types/resource.ts
+++ b/ui/src/types/resource.ts
@@ -1,0 +1,7 @@
+import { Metadata } from './metadata';
+
+export interface Resource {
+  digest: string;
+  metadata?: Metadata;
+  synced?: boolean;
+}


### PR DESCRIPTION
changes the structure a bit.

a phase now has:
1. metadata of its own (name, annotations, labels)
2. a source, which returns its own metadata
3. a resource, which is the state of the source in the phase, containing a digest, optional annotations, and info about if it is in sync of not with the source
4. depends_on, its parent phase

i also added a base resource in the OCI package which implements methods necessary for OCI resource to set its digest and annotations from the manifest

next we will add support for the common OCI annotations in the UI, like:

- `org.opencontainers.image.url`
- `org.opencontainers.image.source`
- `org.opencontainers.image.revision`