### PR TITLE
feat: fetch annotations from oci images

### DIFF
--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"io"
 
 	"github.com/get-glu/glu/pkg/config"
 	"github.com/get-glu/glu/pkg/credentials"
@@ -33,8 +34,8 @@ func New(reference string, cred *credentials.Credential) (_ *Repository, err err
 	return &Repository{repo: repo}, nil
 }
 
-func (r *Repository) Resolve(ctx context.Context) (v1.Descriptor, error) {
-	return r.repo.Resolve(ctx, r.repo.Reference.ReferenceOrDefault())
+func (r *Repository) Resolve(ctx context.Context) (v1.Descriptor, io.ReadCloser, error) {
+	return r.repo.FetchReference(ctx, r.repo.Reference.ReferenceOrDefault())
 }
 
 func (r *Repository) Reference() string {


### PR DESCRIPTION
[repository.Resolve](https://pkg.go.dev/oras.land/oras-go/v2@v2.5.0/registry/remote#Repository.Resolve) only returns the digest, mediaType, and size of the manifest or index (for multi-arch images)

this means it wont give us annotations on the manifests by default

This PR updates to use [repository.FetchReference](https://pkg.go.dev/oras.land/oras-go/v2@v2.5.0/registry/remote#Repository.FetchReference) instead, which gets the entire json manifest

Then we unmarshal it back into the `desc.Descriptor` which should work for both multi-arch manifest indexes and regular single image manifests. This allows us to get the annotations 

## Example API Response

```
{
  "name": "example",
  "phases": [
    {
      "metadata": {
        "name": "production"
      },
      "depends_on": "staging",
      "source": {
        "name": "git"
      },
      "resource": {
        "digest": "7dae8065c9bec489a00c2db34ecb54db788746bce60cc60f86718df20a21ce87"
      }
    },
    {
      "metadata": {
        "name": "oci"
      },
      "source": {
        "name": "oci",
        "annotations": {
          "dev.getglu.oci.image.url": "ghcr.io/{redacted}:latest"
        }
      },
      "resource": {
        "synced": true,
        "digest": "dcd3119a34783675acdbaad09cbce08ba9e94cf7d1ad23e92f2fa5bf5c49ab5c",
        "annotations": {
          "dev.getglu.source.change.url": "https://github.com/{redacted}/pull/624",
          "org.opencontainers.image.created": "2024-11-27T21:32:08.605Z",
          "org.opencontainers.image.description": "example description",
          "org.opencontainers.image.licenses": "",
          "org.opencontainers.image.revision": "ba8f56edea5006a42f35c4138ad24b4d09e7f173",
          "org.opencontainers.image.source": "https://github.com/{redacted}",
          "org.opencontainers.image.title": "gatekeeper",
          "org.opencontainers.image.url": "https://github.com/{redacted}",
          "org.opencontainers.image.version": "pr-624"
        }
      }
    },
    {
      "metadata": {
        "name": "staging"
      },
      "depends_on": "oci",
      "source": {
        "name": "git"
      },
      "resource": {
        "synced": true,
        "digest": "dcd3119a34783675acdbaad09cbce08ba9e94cf7d1ad23e92f2fa5bf5c49ab5c"
      }
    }
  ]
}
```

## Note

We likely want to look into how oras fetches this under the hood, to see if we should implement our own caching/if-not-modified logic as now we're returning more data back than previously from the registry/repository