### PR TITLE
refactor(src/oci): add support for read from index and manifest

### DIFF
--- a/pkg/src/oci/oci.go
+++ b/pkg/src/oci/oci.go
@@ -9,7 +9,6 @@ import (
 	"github.com/get-glu/glu/pkg/phases"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2/content"
 )
 
 const ANNOTATION_OCI_IMAGE_URL = "dev.getglu.oci.image.url"
@@ -18,7 +17,17 @@ var _ phases.Source[Resource] = (*Source[Resource])(nil)
 
 type Resource interface {
 	core.Resource
-	ReadFromOCIDescriptor(v1.Descriptor, io.ReadCloser) error
+	ReadFromOCIDescriptor(v1.Descriptor) error
+}
+
+type ResourceFromManifest interface {
+	Resource
+	ReadFromOCIManifest(v1.Descriptor, v1.Manifest) error
+}
+
+type ResourceFromIndex interface {
+	Resource
+	ReadFromOCIIndex(v1.Descriptor, v1.Index) error
 }
 
 type Resolver interface {
@@ -49,8 +58,47 @@ func (s *Source[R]) View(ctx context.Context, _, _ core.Metadata, r R) error {
 		return err
 	}
 
-	return r.ReadFromOCIDescriptor(desc, reader)
+	defer func() {
+		// discard reader contents and close before returning
+		io.Copy(io.Discard, reader)
+		reader.Close()
+	}()
+
+	switch desc.MediaType {
+	case v1.MediaTypeImageIndex:
+		ri, ok := Resource(r).(ResourceFromIndex)
+		if !ok {
+			break
+		}
+
+		var index v1.Index
+		if err := json.NewDecoder(reader).Decode(&index); err != nil {
+			return err
+		}
+
+		return ri.ReadFromOCIIndex(desc, index)
+	case v1.MediaTypeImageManifest:
+		rm, ok := Resource(r).(ResourceFromManifest)
+		if !ok {
+			break
+		}
+
+		var manifest v1.Manifest
+		if err := json.NewDecoder(reader).Decode(&manifest); err != nil {
+			return err
+		}
+
+		return rm.ReadFromOCIManifest(desc, manifest)
+	default:
+	}
+
+	return r.ReadFromOCIDescriptor(desc)
 }
+
+var (
+	_ ResourceFromIndex    = (*BaseResource)(nil)
+	_ ResourceFromManifest = (*BaseResource)(nil)
+)
 
 type BaseResource struct {
 	// ImageName   string // TODO: add this when we have a use case for it
@@ -66,20 +114,20 @@ func (r *BaseResource) Annotations() map[string]string {
 	return r.annotations
 }
 
-func (r *BaseResource) ReadFromOCIDescriptor(desc v1.Descriptor, reader io.ReadCloser) error {
+func (r *BaseResource) ReadFromOCIDescriptor(desc v1.Descriptor) error {
 	r.ImageDigest = desc.Digest
+	return nil
+}
 
-	defer reader.Close()
+func (r *BaseResource) ReadFromOCIManifest(desc v1.Descriptor, manifest v1.Manifest) error {
+	r.ImageDigest = desc.Digest
+	r.annotations = manifest.Annotations
 
-	b, err := content.ReadAll(reader, desc)
-	if err != nil {
-		return err
-	}
+	return nil
+}
 
-	if err := json.Unmarshal(b, &desc); err != nil {
-		return err
-	}
-
-	r.annotations = desc.Annotations
+func (r *BaseResource) ReadFromOCIIndex(desc v1.Descriptor, index v1.Index) error {
+	r.ImageDigest = desc.Digest
+	r.annotations = index.Annotations
 	return nil
 }

--- a/pkg/src/oci/oci.go
+++ b/pkg/src/oci/oci.go
@@ -9,6 +9,7 @@ import (
 	"github.com/get-glu/glu/pkg/phases"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
 )
 
 const ANNOTATION_OCI_IMAGE_URL = "dev.getglu.oci.image.url"
@@ -92,6 +93,15 @@ func (s *Source[R]) View(ctx context.Context, _, _ core.Metadata, r R) error {
 	default:
 	}
 
+	rest, err := content.ReadAll(reader, desc)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(rest, &desc); err != nil {
+		return err
+	}
+
 	return r.ReadFromOCIDescriptor(desc)
 }
 
@@ -116,6 +126,7 @@ func (r *BaseResource) Annotations() map[string]string {
 
 func (r *BaseResource) ReadFromOCIDescriptor(desc v1.Descriptor) error {
 	r.ImageDigest = desc.Digest
+	r.annotations = desc.Annotations
 	return nil
 }
 


### PR DESCRIPTION
This is a slight refactor make the interfaces a little friendlier.
It attempts a best effort to use the most typed path to getting all necessary information.

I added the ability optionally define both:
```go
ReadFromOCIManifest(v1.Descriptor, v1.Manifest) error
ReadFromOCIIndex(v1.Descriptor, v1.Index) error
```

Now on `View` we switch on the media type of the descriptor and an unexected typed (index or manifest) we attempt to use the relevant `ReadFromOCIManifest` or `ReadFromOCIIndex`.

The BaseResource implements both and so should work for either case depending on what it resolves to.
This removes the need to pass the more opaque reader into `ReadFromOCIDescriptor`.

If it doesn't recognise the type it just attempts the `content.ReadAll` approach automatically into the descriptor (to try and get annotations).