### PR TITLE
feat: add pull request URL to success toast on propose

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -205,7 +205,7 @@ func promoteAllPhases(ctx context.Context, phases iter.Seq[core.Phase], apply bo
 		slog.Info("promoting phase", "phase", phase.Metadata().Name, "dry-run", !apply)
 
 		if apply {
-			if err := phase.Promote(ctx); err != nil {
+			if _, err := phase.Promote(ctx); err != nil {
 				return err
 			}
 		}

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -14,6 +14,8 @@ var (
 	// ErrAlreadyExists is returned when an attempt is made to create a resource
 	// which already exists
 	ErrAlreadyExists = errors.New("already exists")
+	// ErrNoChange is returned when an update produced zero changes
+	ErrNoChange = errors.New("update produced no change")
 )
 
 // Metadata contains the unique information used to identify
@@ -51,8 +53,12 @@ type Phase interface {
 	Metadata() Metadata
 	Source() Metadata
 	Get(context.Context) (Resource, error)
-	Promote(context.Context) error
+	Promote(context.Context) (PromotionResult, error)
 	Synced(context.Context) (bool, error)
+}
+
+type PromotionResult struct {
+	Annotations map[string]string `json:"annotations"`
 }
 
 // AddPhaseOptions are used to configure the addition of a ResourcePhase to a Pipeline

--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -43,9 +43,12 @@ func (t *Trigger) Run(ctx context.Context, p glu.Pipelines) {
 		case <-ticker.C:
 			for _, pipeline := range p.Pipelines() {
 				for phase := range pipeline.Phases(t.options...) {
-					if err := phase.Promote(ctx); err != nil {
+					result, err := phase.Promote(ctx)
+					if err != nil {
 						slog.Error("promoting resource", "name", phase.Metadata().Name, "error", err)
 					}
+
+					slog.Info("promotion succeeded", "annotations", result.Annotations)
 				}
 			}
 

--- a/ui/src/components/node.tsx
+++ b/ui/src/components/node.tsx
@@ -102,7 +102,7 @@ const PhaseNode = ({ data: phase }: NodeProps<PhaseNodeType>) => {
       <div className="mt-2 flex items-center gap-2 text-xs">
         <span>Digest:</span>
         <span className="font-mono text-xs text-muted-foreground">
-          {phase.resource.digest?.slice(-12)}
+          {phase.resource.digest?.slice(0, 12)}
         </span>
       </div>
 

--- a/ui/src/components/node.tsx
+++ b/ui/src/components/node.tsx
@@ -44,7 +44,7 @@ const PhaseNode = ({ data: phase }: NodeProps<PhaseNodeType>) => {
       message = (
         <p>
           Phase promotion proposed:{' '}
-          <a className="underline" href={proposalURL} target="_blank">
+          <a className="underline" href={proposalURL} target="_blank" rel="noopener noreferrer">
             {proposalURL}
           </a>
         </p>

--- a/ui/src/components/node.tsx
+++ b/ui/src/components/node.tsx
@@ -1,5 +1,5 @@
 import { Handle, NodeProps, Position } from '@xyflow/react';
-import { Package, GitBranch, CircleArrowUp, CheckCircle } from 'lucide-react';
+import { Package, GitBranch, CircleArrowUp, CheckCircle, Loader2 } from 'lucide-react';
 import { PhaseNode as PhaseNodeType } from '@/types/flow';
 import { usePromotePhaseMutation } from '@/services/api';
 import {
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
-import { ANNOTATION_OCI_IMAGE_URL } from '@/types/metadata';
+import { ANNOTATION_GIT_PROPOSAL_URL, ANNOTATION_OCI_IMAGE_URL } from '@/types/metadata';
 import { Label } from './label';
 import { TooltipProvider, TooltipTrigger, TooltipContent, Tooltip } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
@@ -28,12 +28,34 @@ const PhaseNode = ({ data: phase }: NodeProps<PhaseNodeType>) => {
   };
 
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [isPromoting, setIsPromoting] = useState(false);
 
   const [promotePhase] = usePromotePhaseMutation();
   const promote = async () => {
+    setIsPromoting(true);
+
+    let message = <p>Phase promotion scheduled</p>;
+    const result = await promotePhase({
+      pipeline: phase.pipeline,
+      phase: phase.metadata.name
+    }).unwrap();
+    const proposalURL = result?.annotations[ANNOTATION_GIT_PROPOSAL_URL];
+    if (proposalURL) {
+      message = (
+        <p>
+          Phase promotion proposed:{' '}
+          <a className="underline" href={proposalURL} target="_blank">
+            {proposalURL}
+          </a>
+        </p>
+      );
+    }
+
+    setIsPromoting(false);
+
+    toast.success(message);
+
     setDialogOpen(false);
-    await promotePhase({ pipeline: phase.pipeline, phase: phase.metadata.name }).unwrap();
-    toast.success('Phase promotion scheduled');
   };
 
   return (
@@ -120,7 +142,15 @@ const PhaseNode = ({ data: phase }: NodeProps<PhaseNodeType>) => {
             <Button variant="outline" onClick={() => setDialogOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={promote}>Promote</Button>
+            <Button onClick={promote}>
+              {isPromoting ? (
+                <>
+                  <Loader2 className="animate-spin" /> Please Wait{' '}
+                </>
+              ) : (
+                'Promote'
+              )}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -1,4 +1,4 @@
-import { Pipeline } from '@/types/pipeline';
+import { Pipeline, Promotion } from '@/types/pipeline';
 import { System } from '@/types/system';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
@@ -14,7 +14,7 @@ export const api = createApi({
     getPipeline: builder.query<Pipeline, string>({
       query: (pipeline) => `/pipelines/${pipeline}`
     }),
-    promotePhase: builder.mutation<void, { pipeline: string; phase: string }>({
+    promotePhase: builder.mutation<Promotion, { pipeline: string; phase: string }>({
       query: ({ pipeline, phase }) => ({
         url: `/pipelines/${pipeline}/phases/${phase}/promote`,
         method: 'POST'

--- a/ui/src/types/metadata.ts
+++ b/ui/src/types/metadata.ts
@@ -5,3 +5,4 @@ export type Metadata = {
 };
 
 export const ANNOTATION_OCI_IMAGE_URL = 'dev.getglu.oci.image.url';
+export const ANNOTATION_GIT_PROPOSAL_URL = 'dev.getglu.git.proposal.url';

--- a/ui/src/types/pipeline.ts
+++ b/ui/src/types/pipeline.ts
@@ -15,5 +15,5 @@ export interface Phase {
 }
 
 export interface Promotion {
-  annotations: Record<string, string>
+  annotations: Record<string, string>;
 }

--- a/ui/src/types/pipeline.ts
+++ b/ui/src/types/pipeline.ts
@@ -13,3 +13,7 @@ export interface Phase {
   depends_on?: string;
   resource: Resource;
 }
+
+export interface Promotion {
+  annotations: Record<string, string>
+}


### PR DESCRIPTION
There are a few extra cleanup details I slipped into this PR.
However, the main aim is to feed forward details from the source update to the UI through a new result type returned on propose.