### PR TITLE
feat(wip): initial implementation of reflog

### DIFF
--- a/examples/oci-and-git/experiment.go
+++ b/examples/oci-and-git/experiment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/get-glu/glu/pkg/builder"
 	"github.com/get-glu/glu/pkg/core"
 	"github.com/get-glu/glu/pkg/fs"
+	"github.com/get-glu/glu/pkg/phases"
 	"github.com/get-glu/glu/pkg/src/git"
 	"github.com/get-glu/glu/pkg/src/oci"
 	"github.com/get-glu/glu/pkg/triggers/schedule"
@@ -43,7 +44,7 @@ func run(ctx context.Context) error {
 			// build a phase for the staging environment which source from the git repository
 			// configure it to promote from the OCI phase
 			staging, err := b.NewPhase(glu.Name("staging", glu.Label("env", "staging")),
-				gitSource, core.PromotesFrom(ociPhase))
+				gitSource, phases.PromotesFrom(ociPhase))
 			if err != nil {
 				return err
 			}
@@ -51,7 +52,7 @@ func run(ctx context.Context) error {
 			// build a phase for the production environment which source from the git repository
 			// configure it to promote from the staging git phase
 			_, err = b.NewPhase(glu.Name("production", glu.Label("env", "production")),
-				gitSource, core.PromotesFrom(staging))
+				gitSource, phases.PromotesFrom(staging))
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,13 @@ require (
 	github.com/go-git/go-billy/v5 v5.6.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/google/go-github/v64 v64.0.0
+	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/stretchr/testify v1.10.0
 	github.com/whilp/git-urls v1.0.0
+	go.etcd.io/bbolt v1.3.11
 	golang.org/x/crypto v0.29.0
 	golang.org/x/oauth2 v0.24.0
 	golang.org/x/sync v0.9.0
@@ -35,7 +38,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.1-0.20240709150035-ccf4b4329d21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/google/go-github/v66 v66.0.0 h1:ADJsaXj9UotwdgK8/iFZtv7MLc8E8WBl62WLd
 github.com/google/go-github/v66 v66.0.0/go.mod h1:+4SO9Zkuyf8ytMj0csN1NR/5OTR+MfqPp8P8dVlcvY4=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -93,6 +95,8 @@ github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgw
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
+go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/go.work.sum
+++ b/go.work.sum
@@ -6,10 +6,5 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
-golang.org/x/crypto v0.29.0 h1:L5SG1JTTXupVV3n6sUqMTeWbjAyfPwoda2DLX8J8FrQ=
-golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
-golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=
-golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+go.etcd.io/gofail v0.1.0/go.mod h1:VZBCXYGZhHAinaBiiqYvuDynvahNsAyLFwB3kEHKz1M=
 golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=
-golang.org/x/term v0.26.0/go.mod h1:Si5m1o57C5nBNQo5z1iq+XDijt21BDBDp2bK0QI8e3E=
-golang.org/x/text v0.20.0/go.mod h1:D4IsuqiFMhST5bX19pQ9ikHC2GsaKyk/oF+pn3ducp4=

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -256,8 +256,17 @@ func (r *Repository) Fetch(ctx context.Context, specific ...string) (err error) 
 		return nil
 	}
 
+	updatedRefs := map[string]plumbing.Hash{}
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	defer func() {
+		r.mu.Unlock()
+
+		// update subscribers if any matching and requested references
+		// are updated while processing this fetch
+		if len(updatedRefs) > 0 {
+			r.updateSubs(ctx, updatedRefs)
+		}
+	}()
 
 	heads := specific
 	if len(heads) == 0 {
@@ -294,7 +303,6 @@ func (r *Repository) Fetch(ctx context.Context, specific ...string) (err error) 
 		return err
 	}
 
-	updatedRefs := map[string]plumbing.Hash{}
 	if err := allRefs.ForEach(func(ref *plumbing.Reference) error {
 		// we're only interested in updates to remotes
 		if !ref.Name().IsRemote() {
@@ -312,8 +320,6 @@ func (r *Repository) Fetch(ctx context.Context, specific ...string) (err error) 
 	}); err != nil {
 		return err
 	}
-
-	r.updateSubs(ctx, updatedRefs)
 
 	return nil
 }
@@ -355,9 +361,12 @@ func (r *Repository) ListCommits(ctx context.Context, branch, from string, filte
 }
 
 type ViewUpdateOptions struct {
-	branch   string
-	revision *plumbing.Hash
-	force    bool
+	branch string
+	// revision on View predicates it to the specific hash
+	// revision on Update returns a conflict error if the branch head does not match
+	revision plumbing.Hash
+	// force configures an update to ignore any conflicts when attempting to push
+	force bool
 }
 
 func (r *Repository) getOptions(opts ...containers.Option[ViewUpdateOptions]) *ViewUpdateOptions {
@@ -372,7 +381,7 @@ func WithBranch(branch string) containers.Option[ViewUpdateOptions] {
 	}
 }
 
-func WithRevision(rev *plumbing.Hash) containers.Option[ViewUpdateOptions] {
+func WithRevision(rev plumbing.Hash) containers.Option[ViewUpdateOptions] {
 	return func(vuo *ViewUpdateOptions) {
 		vuo.revision = rev
 	}
@@ -388,12 +397,15 @@ func (r *Repository) View(ctx context.Context, fn func(hash plumbing.Hash, fs fs
 
 	options := r.getOptions(opts...)
 
-	r.logger.Debug("View", slog.String("branch", options.branch))
-
-	hash, err := r.Resolve(options.branch)
-	if err != nil {
-		return err
+	hash := options.revision
+	if hash == plumbing.ZeroHash {
+		hash, err = r.Resolve(options.branch)
+		if err != nil {
+			return err
+		}
 	}
+
+	r.logger.Debug("View", slog.String("branch", options.branch), slog.String("revision", hash.String()))
 
 	fs, err := r.newFilesystem(hash)
 	if err != nil {
@@ -418,10 +430,8 @@ func (r *Repository) UpdateAndPush(ctx context.Context, fn func(fs fs.Filesystem
 		return plumbing.ZeroHash, err
 	}
 
-	if rev != nil {
-		if *rev != hash {
-			return hash, fmt.Errorf("base revision %q has changed (now %q): %w", rev, hash, errors.New("conflict"))
-		}
+	if rev != plumbing.ZeroHash && rev != hash {
+		return hash, fmt.Errorf("base revision %q has changed (now %q): %w", rev, hash, errors.New("conflict"))
 	}
 
 	// if rev == nil then hash will be the zero hash
@@ -503,7 +513,7 @@ func (r *Repository) updateSubs(ctx context.Context, refs map[string]plumbing.Ha
 }
 
 func refMatch(ref, pattern string) bool {
-	if !strings.Contains(ref, "*") {
+	if !strings.Contains(pattern, "*") {
 		return ref == pattern
 	}
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/get-glu/glu/pkg/containers"
 	"github.com/get-glu/glu/pkg/core"
+	"github.com/get-glu/glu/pkg/phases"
 )
 
 // Pipeline is an alias for the core Pipeline interface (see core.Pipeline)
@@ -16,7 +17,7 @@ type Phase = core.Phase
 
 type entry[R Resource] struct {
 	core.ResourcePhase[R]
-	opts core.AddPhaseOptions[R]
+	opts phases.Options[R]
 }
 
 // ResourcePipeline is a collection of phases for a given resource type R.
@@ -28,18 +29,11 @@ type ResourcePipeline[R Resource] struct {
 }
 
 // NewPipeline constructs and configures a new instance of *ResourcePipeline[R]
-func NewPipeline[R Resource](meta Metadata, newFn func() R) *ResourcePipeline[R] {
+func NewPipeline[R Resource](meta Metadata) *ResourcePipeline[R] {
 	return &ResourcePipeline[R]{
 		meta:  meta,
-		newFn: newFn,
 		nodes: map[string]entry[R]{},
 	}
-}
-
-// New calls the functions underlying resource constructor function to get a
-// new default instance of the resource.
-func (p *ResourcePipeline[R]) New() R {
-	return p.newFn()
 }
 
 // Metadata returns the metadata assocated with the Pipelines (name and labels).
@@ -49,8 +43,8 @@ func (p *ResourcePipeline[R]) Metadata() Metadata {
 
 // Add will add the provided resource phase to the pipeline along with configuring
 // any dependent promotion source phases if configured to do so.
-func (p *ResourcePipeline[R]) Add(r core.ResourcePhase[R], opts ...containers.Option[core.AddPhaseOptions[R]]) error {
-	add := core.AddPhaseOptions[R]{}
+func (p *ResourcePipeline[R]) Add(r core.ResourcePhase[R], opts ...containers.Option[phases.Options[R]]) error {
+	add := phases.Options[R]{}
 	containers.ApplyAll(&add, opts...)
 
 	if _, existing := p.nodes[r.Metadata().Name]; existing {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -6,6 +6,7 @@ import (
 	"iter"
 
 	"github.com/get-glu/glu/pkg/containers"
+	"github.com/google/uuid"
 )
 
 var (
@@ -55,22 +56,17 @@ type Phase interface {
 	Get(context.Context) (Resource, error)
 	Promote(context.Context) (PromotionResult, error)
 	Synced(context.Context) (bool, error)
+	History(context.Context) ([]State, error)
 }
 
 type PromotionResult struct {
 	Annotations map[string]string `json:"annotations"`
 }
 
-// AddPhaseOptions are used to configure the addition of a ResourcePhase to a Pipeline
-type AddPhaseOptions[R Resource] struct {
-	PromotedFrom ResourcePhase[R]
-}
-
-// PromotesFrom configures a dependent Phase to promote from for the Phase being added.
-func PromotesFrom[R Resource](c ResourcePhase[R]) containers.Option[AddPhaseOptions[R]] {
-	return func(o *AddPhaseOptions[R]) {
-		o.PromotedFrom = c
-	}
+type State struct {
+	Version     uuid.UUID
+	Resource    Resource
+	Annotations map[string]string
 }
 
 // ResourcePhase is a Phase bound to a particular resource type R.

--- a/pkg/phases/phases.go
+++ b/pkg/phases/phases.go
@@ -13,8 +13,10 @@ import (
 type Source[R core.Resource] interface {
 	Metadata() core.Metadata
 	View(_ context.Context, pipeline, phase core.Metadata, _ R) error
+	Subscribe(pipeline, phase core.Metadata, newFn func() R, record func(R, map[string]string))
 }
 
+// UpdatableSource is a source through which the phase can promote resources to new versions
 type UpdatableSource[R core.Resource] interface {
 	Source[R]
 	Update(_ context.Context, pipeline, phase core.Metadata, from, to R) (map[string]string, error)
@@ -22,21 +24,49 @@ type UpdatableSource[R core.Resource] interface {
 
 // Pipeline is a set of phase with promotion dependencies between one another.
 type Pipeline[R core.Resource] interface {
-	New() R
 	Metadata() core.Metadata
-	Add(r core.ResourcePhase[R], opts ...containers.Option[core.AddPhaseOptions[R]]) error
+	Add(r core.ResourcePhase[R], opts ...containers.Option[Options[R]]) error
 	PromotedFrom(core.ResourcePhase[R]) (core.ResourcePhase[R], bool)
 }
 
+// Options are used to configure the addition of a ResourcePhase to a Pipeline
+type Options[R core.Resource] struct {
+	PromotedFrom core.ResourcePhase[R]
+	Log          RefLog[R]
+}
+
+// PromotesFrom configures a dependent Phase to promote from for the Phase being added.
+func PromotesFrom[R core.Resource](c core.ResourcePhase[R]) containers.Option[Options[R]] {
+	return func(o *Options[R]) {
+		o.PromotedFrom = c
+	}
+}
+
+// LogsTo adds a reference log to the phase.
+func LogsTo[R core.Resource](l RefLog[R]) containers.Option[Options[R]] {
+	return func(o *Options[R]) {
+		o.Log = l
+	}
+}
+
+type RefLog[R core.Resource] interface {
+	CreateReference(ctx context.Context, pipeline, phase core.Metadata) error
+	RecordLatest(ctx context.Context, pipeline, phase core.Metadata, resource R, annotations map[string]string) error
+	History(ctx context.Context, pipeline, phase core.Metadata) ([]core.State, error)
+}
+
 type Phase[R core.Resource] struct {
+	Options[R]
+
 	logger   *slog.Logger
 	meta     core.Metadata
 	pipeline Pipeline[R]
 	source   Source[R]
+	newFn    func() R
 }
 
-func New[R core.Resource](meta core.Metadata, pipeline Pipeline[R], repo Source[R], opts ...containers.Option[core.AddPhaseOptions[R]]) (*Phase[R], error) {
-	logger := slog.With("name", meta.Name, "pipeline", pipeline.Metadata().Name)
+func New[R core.Resource](meta core.Metadata, pipeline Pipeline[R], source Source[R], newFn func() R, opts ...containers.Option[Options[R]]) (*Phase[R], error) {
+	logger := slog.With("phase", meta.Name, "pipeline", pipeline.Metadata().Name)
 	for k, v := range meta.Labels {
 		logger = logger.With(k, v)
 	}
@@ -45,11 +75,27 @@ func New[R core.Resource](meta core.Metadata, pipeline Pipeline[R], repo Source[
 		logger:   logger,
 		meta:     meta,
 		pipeline: pipeline,
-		source:   repo,
+		source:   source,
+		newFn:    newFn,
 	}
+
+	containers.ApplyAll(&phase.Options, opts...)
 
 	if err := pipeline.Add(phase, opts...); err != nil {
 		return nil, err
+	}
+
+	if phase.Log != nil {
+		ctx := context.Background()
+		if err := phase.Log.CreateReference(ctx, pipeline.Metadata(), phase.meta); err != nil {
+			return nil, err
+		}
+
+		source.Subscribe(pipeline.Metadata(), phase.meta, newFn, func(r R, m map[string]string) {
+			if err := phase.Log.RecordLatest(ctx, pipeline.Metadata(), phase.meta, r, m); err != nil {
+				logger.Error("recording latest ref", "error", err)
+			}
+		})
 	}
 
 	return phase, nil
@@ -69,7 +115,7 @@ func (i *Phase[R]) Get(ctx context.Context) (core.Resource, error) {
 
 // GetResource returns the identified resource as its concrete pointer type.
 func (i *Phase[R]) GetResource(ctx context.Context) (a R, err error) {
-	a = i.pipeline.New()
+	a = i.newFn()
 	if err := i.source.View(ctx, i.pipeline.Metadata(), i.meta, a); err != nil {
 		return a, err
 	}
@@ -95,73 +141,65 @@ func (i *Phase[R]) Promote(ctx context.Context) (r core.PromotionResult, err err
 		return r, nil
 	}
 
-	from := i.pipeline.New()
-	if err := i.source.View(ctx, i.pipeline.Metadata(), i.meta, from); err != nil {
-		return r, err
-	}
-
-	dep, ok := i.pipeline.PromotedFrom(i)
-	if !ok {
-		return r, nil
-	}
-
-	to, err := dep.GetResource(ctx)
+	from, to, synced, err := i.synced(ctx)
 	if err != nil {
 		return r, err
 	}
 
-	fromDigest, err := from.Digest()
-	if err != nil {
-		return r, err
-	}
-
-	toDigest, err := to.Digest()
-	if err != nil {
-		return r, err
-	}
-
-	if fromDigest == toDigest {
+	if synced {
 		i.logger.Debug("skipping promotion", "reason", "UpToDate")
 		return r, nil
 	}
 
 	if r.Annotations, err = updatable.Update(ctx, i.pipeline.Metadata(), i.meta, from, to); err != nil {
-		return r, fmt.Errorf("updating from %q to %q: %w", fromDigest, toDigest, err)
+		return r, err
 	}
 
 	return r, nil
 }
 
 func (i *Phase[R]) Synced(ctx context.Context) (bool, error) {
-	from := i.pipeline.New()
+	_, _, synced, err := i.synced(ctx)
+	return synced, err
+}
+
+func (i *Phase[R]) synced(ctx context.Context) (from, to R, synced bool, err error) {
+	from = i.newFn()
 	if err := i.source.View(ctx, i.pipeline.Metadata(), i.meta, from); err != nil {
-		return false, err
+		return from, to, false, err
 	}
 
 	dep, ok := i.pipeline.PromotedFrom(i)
 	if !ok {
-		return true, nil
+		return from, to, true, nil
 	}
 
-	to, err := dep.GetResource(ctx)
+	to, err = dep.GetResource(ctx)
 	if err != nil {
-		return false, err
+		return from, to, false, err
 	}
 
 	fromDigest, err := from.Digest()
 	if err != nil {
-		return false, err
+		return from, to, false, err
 	}
 
 	toDigest, err := to.Digest()
 	if err != nil {
-		return false, err
+		return from, to, false, err
 	}
 
 	if fromDigest == toDigest {
-
-		return true, nil
+		return from, to, true, nil
 	}
 
-	return false, nil
+	return from, to, false, nil
+}
+
+func (i *Phase[R]) History(ctx context.Context) ([]core.State, error) {
+	if i.Options.Log == nil {
+		return nil, nil
+	}
+
+	return i.Options.Log.History(ctx, i.pipeline.Metadata(), i.meta)
 }

--- a/pkg/reflog/log.go
+++ b/pkg/reflog/log.go
@@ -1,0 +1,233 @@
+package reflog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/get-glu/glu/pkg/core"
+	"github.com/google/uuid"
+	"go.etcd.io/bbolt"
+)
+
+const (
+	versionBucket = "v0"
+	blobsBucket   = "blobs"
+	refBucket     = "refs"
+)
+
+var (
+	ErrBucketNotFound = errors.New("bucket not found")
+)
+
+type Log[R core.Resource] struct {
+	db      *bbolt.DB
+	encoder func(any) ([]byte, error)
+	decoder func([]byte, any) error
+	last    map[string]map[string]version
+}
+
+func New[R core.Resource](db *bbolt.DB) *Log[R] {
+	return &Log[R]{
+		db:      db,
+		encoder: json.Marshal,
+		decoder: json.Unmarshal,
+		last:    map[string]map[string]version{},
+	}
+}
+
+type version struct {
+	Digest      []byte
+	Annotations map[string]string
+}
+
+func (l *Log[R]) CreateReference(ctx context.Context, pipeline, phase core.Metadata) error {
+	return l.db.Update(func(tx *bbolt.Tx) error {
+		if _, err := createBucketPath(tx, versionBucket, refBucket, pipeline.Name, phase.Name); err != nil {
+			return err
+		}
+
+		_, err := createBucketPath(tx, versionBucket, blobsBucket, pipeline.Name, phase.Name)
+		return err
+	})
+}
+
+func (l *Log[R]) RecordLatest(ctx context.Context, pipeline, phase core.Metadata, resource R, annotations map[string]string) error {
+	slog := slog.With("pipeline", pipeline.Name, "phase", phase.Name)
+	return l.db.Update(func(tx *bbolt.Tx) error {
+		digest, err := resource.Digest()
+		if err != nil {
+			return err
+		}
+
+		refs, err := getRefsBucket(pipeline, phase, tx)
+		if err != nil {
+			return err
+		}
+
+		curLatest, ok := l.getLatestVersion(refs, pipeline, phase)
+		if ok && bytes.Equal(curLatest.Digest, []byte(digest)) {
+			slog.Debug("skipped recording latest", "reason", "NoChange")
+			return nil
+		}
+
+		blobs, err := getBlobBucket(pipeline, phase, tx)
+		if err != nil {
+			return err
+		}
+
+		// insert encoded resource if digest not already persisted
+		if v := blobs.Get([]byte(digest)); v == nil {
+			data, err := l.encoder(resource)
+			if err != nil {
+				return err
+			}
+
+			if err := blobs.Put([]byte(digest), data); err != nil {
+				return err
+			}
+		}
+
+		encoded, err := l.encoder(version{[]byte(digest), annotations})
+		if err != nil {
+			return err
+		}
+
+		id, err := uuid.NewV7()
+		if err != nil {
+			return err
+		}
+
+		idBytes, err := id.MarshalText()
+		if err != nil {
+			return err
+		}
+
+		return refs.Put(idBytes, encoded)
+	})
+}
+
+func (l *Log[R]) getLatestVersion(refs *bbolt.Bucket, pipeline, phase core.Metadata) (version, bool) {
+	phases, ok := l.last[pipeline.Name]
+	if !ok {
+		phases = map[string]version{}
+		l.last[phase.Name] = phases
+	}
+
+	version, ok := phases[phase.Name]
+	if !ok {
+		version, ok = l.fetchLatestVersion(refs)
+		if !ok {
+			return version, false
+		}
+
+		phases[phase.Name] = version
+	}
+
+	return version, true
+}
+
+func (l *Log[R]) fetchLatestVersion(refs *bbolt.Bucket) (v version, _ bool) {
+	k, data := refs.Cursor().Last()
+	if k == nil {
+		return v, false
+	}
+
+	if err := l.decoder(data, &v); err != nil {
+		return v, false
+	}
+
+	return v, true
+}
+
+func (l *Log[R]) History(ctx context.Context, pipeline, phase core.Metadata) (states []core.State, _ error) {
+	return states, l.db.View(func(tx *bbolt.Tx) error {
+		refs, err := getRefsBucket(pipeline, phase, tx)
+		if err != nil {
+			return err
+		}
+
+		blobs, err := getBlobBucket(pipeline, phase, tx)
+		if err != nil {
+			return err
+		}
+
+		// run a cursor in reverse to descend from most recent (largest) to oldest (smallest)
+		cursor := refs.Cursor()
+		for k, v := cursor.Last(); k != nil; k, v = cursor.Prev() {
+			id, err := uuid.ParseBytes(k)
+			if err != nil {
+				return err
+			}
+
+			var version version
+			if err := l.decoder(v, &version); err != nil {
+				return err
+			}
+
+			var r R
+			if blob := blobs.Get(version.Digest); blob != nil {
+				if err := l.decoder(blob, &r); err != nil {
+					return err
+				}
+			}
+
+			states = append(states, core.State{
+				Version:     id,
+				Resource:    r,
+				Annotations: version.Annotations,
+			})
+		}
+
+		return nil
+	})
+}
+
+func getBlobBucket(pipeline, phase core.Metadata, tx *bbolt.Tx) (*bbolt.Bucket, error) {
+	return getBucket(tx, versionBucket, blobsBucket, pipeline.Name, phase.Name)
+}
+
+func getRefsBucket(pipeline, phase core.Metadata, tx *bbolt.Tx) (*bbolt.Bucket, error) {
+	return getBucket(tx, versionBucket, refBucket, pipeline.Name, phase.Name)
+}
+
+func getBucket(tx *bbolt.Tx, path ...string) (bkt *bbolt.Bucket, err error) {
+	if len(path) == 0 {
+		return nil, fmt.Errorf("empty path: %w", ErrBucketNotFound)
+	}
+
+	var b interface {
+		Bucket([]byte) *bbolt.Bucket
+	} = tx
+
+	for i, p := range path {
+		if bkt = b.Bucket([]byte(p)); bkt == nil {
+			return nil, fmt.Errorf("bucket %q: %w", strings.Join(path[:i+1], "/"), ErrBucketNotFound)
+		}
+		b = bkt
+	}
+	return
+}
+
+func createBucketPath(tx *bbolt.Tx, path ...string) (bkt *bbolt.Bucket, err error) {
+	if len(path) == 0 {
+		return nil, fmt.Errorf("empty path: %w", ErrBucketNotFound)
+	}
+
+	var b interface {
+		CreateBucketIfNotExists([]byte) (*bbolt.Bucket, error)
+	} = tx
+
+	for i, p := range path {
+		if bkt, err = b.CreateBucketIfNotExists([]byte(p)); err != nil {
+			return nil, fmt.Errorf("bucket %q: %w", strings.Join(path[:i+1], "/"), err)
+		}
+
+		b = bkt
+	}
+	return
+}

--- a/pkg/src/oci/oci.go
+++ b/pkg/src/oci/oci.go
@@ -3,6 +3,7 @@ package oci
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/get-glu/glu/pkg/core"
@@ -51,6 +52,10 @@ func (s *Source[R]) Metadata() core.Metadata {
 		Name:        "oci",
 		Annotations: map[string]string{ANNOTATION_OCI_IMAGE_URL: s.resolver.Reference()},
 	}
+}
+
+func (g *Source[R]) Subscribe(pipeline, phase core.Metadata, newFn func() R, record func(R, map[string]string)) {
+	panic("not implemented")
 }
 
 func (s *Source[R]) View(ctx context.Context, _, _ core.Metadata, r R) error {
@@ -103,6 +108,10 @@ func (s *Source[R]) View(ctx context.Context, _, _ core.Metadata, r R) error {
 	}
 
 	return r.ReadFromOCIDescriptor(desc)
+}
+
+func (s *Source[A]) History(ctx context.Context, pipeline, phase core.Metadata) ([]core.State, error) {
+	return nil, errors.New("not implemented")
 }
 
 var (


### PR DESCRIPTION
Opening this up as a draft before I checkout for the weekend.

This will ultimately add reflog support.
Where refs in this case are the tuple of pipeline and phase name (maybe with resource type name in future too).

The initial implementation of using bbolt for persistence.
However, this could be a puggable thing.

The log tracks the heads of each pipeline+phase over time.
When and only when the target resource advanced (the digest changes) does it commit a new version to history.

The product of this is a discrete set of histories which match the developers pipelines and phases.

Ultimately, this will power history and rollback features.