### PR TITLE
fix: metrics import issue

### DIFF
--- a/glu.go
+++ b/glu.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	metricsdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"golang.org/x/sync/errgroup"
 )
 


### PR DESCRIPTION
Fixes:

```
time=2024-12-02T12:44:33.695-05:00 level=ERROR msg="error running mock server" error="creating metrics resource: error detecting resource: conflicting Schema URL: https://opentelemetry.io/schemas/1.17.0 and https://opentelemetry.io/schemas/1.26.0"
```