### PR TITLE
chore: fix ui

### DIFF
--- a/examples/fakedata/main.go
+++ b/examples/fakedata/main.go
@@ -9,10 +9,11 @@ import (
 	"github.com/get-glu/glu/pkg/core"
 	"github.com/get-glu/glu/pkg/edges"
 	"github.com/get-glu/glu/pkg/pipelines"
+	"github.com/get-glu/glu/ui"
 )
 
 func run(ctx context.Context) error {
-	system := glu.NewSystem(ctx, glu.Name("mycorp", glu.Label("team", "ecommerce")))
+	system := glu.NewSystem(ctx, glu.Name("mycorp", glu.Label("team", "ecommerce")), glu.WithUI(ui.FS()))
 	config, err := system.Configuration()
 	if err != nil {
 		return err

--- a/examples/oci-and-git/experiment.go
+++ b/examples/oci-and-git/experiment.go
@@ -8,15 +8,16 @@ import (
 	"github.com/get-glu/glu"
 	"github.com/get-glu/glu/pkg/edges"
 	"github.com/get-glu/glu/pkg/fs"
-	"github.com/get-glu/glu/pkg/pipelines"
 	"github.com/get-glu/glu/pkg/phases/git"
 	"github.com/get-glu/glu/pkg/phases/oci"
+	"github.com/get-glu/glu/pkg/pipelines"
+	"github.com/get-glu/glu/ui"
 	"github.com/opencontainers/go-digest"
 	"gopkg.in/yaml.v3"
 )
 
 func run(ctx context.Context) error {
-	system := glu.NewSystem(ctx, glu.Name("mypipelines"))
+	system := glu.NewSystem(ctx, glu.Name("mypipelines"), glu.WithUI(ui.FS()))
 	config, err := system.Configuration()
 	if err != nil {
 		return err

--- a/ui/src/components/button-edge.tsx
+++ b/ui/src/components/button-edge.tsx
@@ -80,7 +80,7 @@ export function ButtonEdge({
       <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
       <EdgeLabelRenderer>
         <div
-          className="nodrag nopan pointer-events-auto absolute"
+          className="nodrag nopan pointer-events-auto absolute mt-4"
           style={{
             transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`
           }}

--- a/ui/src/components/node-panel.tsx
+++ b/ui/src/components/node-panel.tsx
@@ -1,6 +1,5 @@
 import { PhaseNode } from '@/types/flow';
-import { Package, GitBranch, ChevronDown, ChevronUp, CheckCircle, CircleAlert } from 'lucide-react';
-import { TooltipProvider, TooltipTrigger, Tooltip, TooltipContent } from '@/components/ui/tooltip';
+import { Package, GitBranch, ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
 import { Label } from './label';
@@ -15,7 +14,7 @@ export function NodePanel({ node, isExpanded, onToggle }: NodePanelProps) {
   if (!node) return null;
 
   const getIcon = () => {
-    switch (node.data.source.name ?? '') {
+    switch (node.data.kind ?? '') {
       case 'oci':
         return <Package className="h-4 w-4" />;
       default:
@@ -28,34 +27,7 @@ export function NodePanel({ node, isExpanded, onToggle }: NodePanelProps) {
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center gap-2">
           {getIcon()}
-          <h2 className="text-lg font-semibold">{node.data.metadata.name}</h2>
-          {node.data.depends_on && node.data.depends_on !== '' && (
-            <>
-              {node.data.resource.synced ? (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <CheckCircle className="h-4 w-4 flex-shrink-0 text-green-400" />
-                    </TooltipTrigger>
-                    <TooltipContent sideOffset={5} className="text-xs">
-                      Up to Date
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              ) : (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <CircleAlert className="h-4 w-4 flex-shrink-0 cursor-pointer" />
-                    </TooltipTrigger>
-                    <TooltipContent sideOffset={5} className="text-xs">
-                      Out of Sync
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-            </>
-          )}
+          <h2 className="text-lg font-semibold">{node.data.descriptor.metadata.name}</h2>
         </div>
         <Button variant="ghost" size="sm" onClick={onToggle}>
           {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
@@ -74,11 +46,7 @@ export function NodePanel({ node, isExpanded, onToggle }: NodePanelProps) {
             <div className="mt-2 space-y-2">
               <div className="text-sm">
                 <span className="text-muted-foreground">Pipeline: </span>
-                {node.data.pipeline}
-              </div>
-              <div className="text-sm">
-                <span className="text-muted-foreground">Depends on: </span>
-                {node.data.depends_on || 'None'}
+                {node.data.descriptor.pipeline}
               </div>
               <div className="text-sm">
                 <span className="text-muted-foreground">Digest: </span>
@@ -89,17 +57,17 @@ export function NodePanel({ node, isExpanded, onToggle }: NodePanelProps) {
         </div>
 
         <div className="space-y-4 overflow-hidden p-4">
-          {node.data.metadata.labels && Object.keys(node.data.metadata.labels).length > 0 && (
-            <div>
-              <h3 className="text-sm font-medium">Labels</h3>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {node.data.metadata.labels &&
-                  Object.entries(node.data.metadata.labels).map(([key, value]) => (
+          {node.data.descriptor.metadata.labels &&
+            Object.keys(node.data.descriptor.metadata.labels).length > 0 && (
+              <div>
+                <h3 className="text-sm font-medium">Labels</h3>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {Object.entries(node.data.descriptor.metadata.labels).map(([key, value]) => (
                     <Label key={key} labelKey={key} value={value} />
                   ))}
+                </div>
               </div>
-            </div>
-          )}
+            )}
         </div>
       </div>
     </div>

--- a/ui/src/components/pipeline.tsx
+++ b/ui/src/components/pipeline.tsx
@@ -17,7 +17,7 @@ import { Pipeline as PipelineType } from '@/types/pipeline';
 import { FlowPipeline, PipelineEdge, PhaseNode, PipelineNode } from '@/types/flow';
 import Dagre from '@dagrejs/dagre';
 import { NodePanel } from '@/components/node-panel';
-import { ButtonEdge } from './ButtonEdge';
+import { ButtonEdge } from './button-edge';
 
 const nodeTypes = {
   phase: PhaseNodeComponent

--- a/ui/src/types/flow.ts
+++ b/ui/src/types/flow.ts
@@ -14,7 +14,7 @@ type PhaseNodeData = Phase & Record<string, unknown>;
 export type PhaseNode = Node<PhaseNodeData, 'phase'>;
 
 export type PipelineEdge = Edge<{
-  king: string;
+  kind: string;
   from: Descriptor;
   to: Descriptor;
   can_perform: boolean;


### PR DESCRIPTION
- fixes node-panel errors
- removes 'depends on' from node panel as it would now require passing in the edges too, can do this if we think its useful to put back though
- adds a bit of space between the edge and the promote icon as it looked weird in light mode when they overlapped

![CleanShot 2024-12-02 at 13 57 04@2x](https://github.com/user-attachments/assets/98bbfc10-12cd-450b-bfca-a9e023089c62)
