### PR TITLE
refactor: pass entire system to pipelines.NewBuilder

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -3,30 +3,30 @@
 Glu has an opinionated set of models and abstractions, which when combined, allow you to build consistent command-line and server processes for orchestrating the progression of applications and configuration across target environments.
 
 ```go
-if err := pipelines.NewBuilder(config, glu.Name("checkout"), NewCheckoutResource).
-        // build an OCI phase from the OCI source named "checkout"
-		NewPhase(func(b pipelines.Builder[*CheckoutResource]) (edges.Phase[*CheckoutResource], error) {
-			return pipelines.OCIPhase(b, glu.Name("oci"), "checkout")
-		}).
-        // build a phase for the staging environment from the git repo source named "checkout"
-        // and configure it to promote from the OCI phase
-		PromotesTo(func(b pipelines.Builder[*CheckoutResource]) (edges.UpdatablePhase[*CheckoutResource], error) {
-			return pipelines.GitPhase(b, glu.Name("staging", glu.Label("env", "staging")), "checkout",
-				git.ProposeChanges[*CheckoutResource](git.ProposalOption{
-					Labels: []string{"automerge"},
-				}))
-		}, schedule.New(
-            // configure the promotion to run every 30 seconds
-			schedule.WithInterval(30*time.Second),
-		)).
-        // build a phase for the production environment from the git repo source named "checkout"
-        // and configure it to promote from the staging git phase
-		PromotesTo(func(b pipelines.Builder[*CheckoutResource]) (edges.UpdatablePhase[*CheckoutResource], error) {
-			return pipelines.GitPhase(b, glu.Name("production", glu.Label("env", "production")), "checkout")
-		}).
-		Build(system); err != nil {
-		return err
-	}
+if err := pipelines.NewBuilder(system, glu.Name("checkout"), NewCheckoutResource).
+    // build an OCI phase from the OCI source named "checkout"
+    NewPhase(func(b pipelines.Builder[*CheckoutResource]) (edges.Phase[*CheckoutResource], error) {
+        return pipelines.OCIPhase(b, glu.Name("oci"), "checkout")
+    }).
+    // build a phase for the staging environment from the git repo source named "checkout"
+    // and configure it to promote from the OCI phase
+    PromotesTo(func(b pipelines.Builder[*CheckoutResource]) (edges.UpdatablePhase[*CheckoutResource], error) {
+        return pipelines.GitPhase(b, glu.Name("staging", glu.Label("env", "staging")), "checkout",
+            git.ProposeChanges[*CheckoutResource](git.ProposalOption{
+                Labels: []string{"automerge"},
+            }))
+    }, schedule.New(
+        // configure the promotion to run every 30 seconds
+        schedule.WithInterval(30*time.Second),
+    )).
+    // build a phase for the production environment from the git repo source named "checkout"
+    // and configure it to promote from the staging git phase
+    PromotesTo(func(b pipelines.Builder[*CheckoutResource]) (edges.UpdatablePhase[*CheckoutResource], error) {
+        return pipelines.GitPhase(b, glu.Name("production", glu.Label("env", "production")), "checkout")
+    }).
+    Build(system); err != nil {
+    return err
+}
 ```
 
 The Glu framework comprises of a set of abstractions for declaring the resources (your applications and configuration), update strategies (we call them phases) and rules for progression (how and when to promote) within a pipeline.

--- a/docs/guides/gitops-implementation.md
+++ b/docs/guides/gitops-implementation.md
@@ -57,15 +57,11 @@ Every Glu codebase starts with a `glu.System`. A system is a container for your 
 In the GitOps example, you will find a `main.go`. In this, you will find `main()` function, which calls a function `run(ctx) error`.
 This function is where we first get introduced to our new glu system instance.
 
-We start by creating a system and getting our pre-built configuration (this comes in handy configuring our phases later).
+We start by creating a system:
 
 ```go
 func run(ctx context.Context) error {
     system := glu.NewSystem(ctx, glu.Name("gitops-example"), glu.WithUI(ui.FS()))
-	config, err := system.Configuration()
-	if err != nil {
-		return err
-	}
 
     // ...
 }
@@ -95,7 +91,7 @@ The package provides lots of useful convenience functions for quickly building i
 Its purpose and goal is to provide a form of cached dependency injection for system and pipeline composition.
 
 ```go
-pipelines.NewBuilder(config, glu.Name("gitops-example-app"), func() *AppResource {
+pipelines.NewBuilder(system, glu.Name("gitops-example-app"), func() *AppResource {
     return &AppResource{
         Image: "ghcr.io/get-glu/gitops-example/app",
     }
@@ -121,15 +117,15 @@ To add a new pipeline, we normally call `system.AddPipeline()`, which takes an i
 system.AddPipeline(glu.Pipeline)
 ```
 
-However, our handy `pipelines.PipelineBuilder` has a final method `build.Build(system)` for registering the built pipeline at the end of the creating and adding all our phases:
+However, our handy `pipelines.PipelineBuilder` has a final method `build.Build()` for registering the built pipeline at the end of the creating and adding all our phases:
 
 ```go
-if err := pipelines.NewBuilder(config, glu.Name("gitops-example-app"), func() *AppResource {
+if err := pipelines.NewBuilder(system, glu.Name("gitops-example-app"), func() *AppResource {
     return &AppResource{
         Image: "ghcr.io/get-glu/gitops-example/app",
     }
 // ...
-}).Build(system); err != nil {
+}).Build(); err != nil {
     return err
 }
 ```

--- a/examples/fakedata/main.go
+++ b/examples/fakedata/main.go
@@ -14,12 +14,7 @@ import (
 
 func run(ctx context.Context) error {
 	system := glu.NewSystem(ctx, glu.Name("mycorp", glu.Label("team", "ecommerce")), glu.WithUI(ui.FS()))
-	config, err := system.Configuration()
-	if err != nil {
-		return err
-	}
-
-	checkout := pipelines.NewBuilder(ctx, config, glu.Name("checkout"), NewMockResource)
+	checkout := pipelines.NewBuilder(system, glu.Name("checkout"), NewMockResource)
 	// oci promotes to staging
 	stagingPhase := checkout.
 		// oci phase
@@ -41,11 +36,11 @@ func run(ctx context.Context) error {
 		return NewMockPhase("checkout", "git", "production-east-2"), nil
 	})
 
-	if err := checkout.Build(system); err != nil {
+	if err := checkout.Build(); err != nil {
 		return err
 	}
 
-	billing := pipelines.NewBuilder(ctx, config, glu.Name("billing"), NewMockResource).
+	billing := pipelines.NewBuilder(system, glu.Name("billing"), NewMockResource).
 		// oci phase
 		NewPhase(func(pipelines.Builder[*MockResource]) (edges.Phase[*MockResource], error) {
 			return NewMockPhase("billing", "oci", "oci"), nil
@@ -59,7 +54,7 @@ func run(ctx context.Context) error {
 			return NewMockPhase("billing", "git", "production"), nil
 		})
 
-	if err := billing.Build(system); err != nil {
+	if err := billing.Build(); err != nil {
 		return err
 	}
 

--- a/examples/oci-and-git/experiment.go
+++ b/examples/oci-and-git/experiment.go
@@ -20,12 +20,7 @@ import (
 
 func run(ctx context.Context) error {
 	system := glu.NewSystem(ctx, glu.Name("mypipelines"), glu.WithUI(ui.FS()))
-	config, err := system.Configuration()
-	if err != nil {
-		return err
-	}
-
-	if err := pipelines.NewBuilder(ctx, config, glu.Name("checkout"), NewCheckoutResource).
+	if err := pipelines.NewBuilder(system, glu.Name("checkout"), NewCheckoutResource).
 		NewPhase(func(b pipelines.Builder[*CheckoutResource]) (edges.Phase[*CheckoutResource], error) {
 			// fetch the configured OCI repositority source named "checkout"
 			return pipelines.OCIPhase(b, glu.Name("oci"), "checkout")
@@ -45,7 +40,7 @@ func run(ctx context.Context) error {
 			// configure it to promote from the staging git phase
 			return pipelines.GitPhase(b, glu.Name("production", glu.Label("env", "production")), "checkout")
 		}).
-		Build(system); err != nil {
+		Build(); err != nil {
 		return err
 	}
 

--- a/glu.go
+++ b/glu.go
@@ -127,6 +127,11 @@ func NewSystem(ctx context.Context, meta Metadata, opts ...containers.Option[Sys
 	return r
 }
 
+// Context returns the systems root context.
+func (s *System) Context() context.Context {
+	return s.ctx
+}
+
 // GetPipeline returns a pipeline by name.
 func (s *System) GetPipeline(name string) (*core.Pipeline, error) {
 	pipeline, ok := s.pipelines[name]


### PR DESCRIPTION
Quick change to adjust how context and config gets threaded onto the pipelines builder.
Now it just passes the whole system to the builder.
This simplfies some things when using the builder.