### PR TITLE
feat(phases/git): implement rollback on the server side

### DIFF
--- a/pkg/core/pipeline.go
+++ b/pkg/core/pipeline.go
@@ -19,6 +19,14 @@ type Phase interface {
 	History(context.Context) ([]State, error)
 }
 
+// RollbackPhase is a phase which can be rolled back to a previous version.
+type RollbackPhase interface {
+	Phase
+	// Rollback performs a rollback operation to a previous state identified
+	// by a version uuid.
+	Rollback(context.Context, uuid.UUID) error
+}
+
 // State contains a snapshot of a resource version at a point in history
 type State struct {
 	Version     uuid.UUID         `json:"version,omitempty"`

--- a/pkg/core/pipeline.go
+++ b/pkg/core/pipeline.go
@@ -24,7 +24,7 @@ type RollbackPhase interface {
 	Phase
 	// Rollback performs a rollback operation to a previous state identified
 	// by a version uuid.
-	Rollback(context.Context, uuid.UUID) error
+	Rollback(context.Context, uuid.UUID) (*Result, error)
 }
 
 // State contains a snapshot of a resource version at a point in history
@@ -105,7 +105,7 @@ type Edge interface {
 	Kind() string
 	From() Descriptor
 	To() Descriptor
-	Perform(context.Context) (Result, error)
+	Perform(context.Context) (*Result, error)
 	CanPerform(context.Context) (bool, error)
 }
 

--- a/pkg/core/typed/typed.go
+++ b/pkg/core/typed/typed.go
@@ -1,0 +1,67 @@
+package typed
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/get-glu/glu/pkg/containers"
+	"github.com/get-glu/glu/pkg/core"
+)
+
+var (
+	KindUpdate    = "update"
+	KindPromotion = "promotion"
+	KindRollback  = "rollback"
+)
+
+// Phase is an interface around storage for resources.
+type Phase[R core.Resource] interface {
+	core.Phase
+	GetResource(_ context.Context) (R, error)
+}
+
+// UpdatablePhase is a source through which the phase can promote resources to new versions
+type UpdatablePhase[R core.Resource] interface {
+	Phase[R]
+	Update(_ context.Context, to R, opts ...containers.Option[UpdateOptions]) (*core.Result, error)
+}
+
+// UpdateOptions carries some context regarding the update
+type UpdateOptions struct {
+	Kind string
+}
+
+// NewUpdateOptions converts a list of UpdateOptions functional options
+// into an instacne of *UpdateOptions.
+func NewUpdateOptions(opts ...containers.Option[UpdateOptions]) *UpdateOptions {
+	def := &UpdateOptions{Kind: KindUpdate}
+	containers.ApplyAll(def, opts...)
+	return def
+}
+
+// UpdateWithKind configures an UpdateOptions with a specific kind.
+func UpdateWithKind(kind string) containers.Option[UpdateOptions] {
+	return func(o *UpdateOptions) {
+		o.Kind = kind
+	}
+}
+
+func (o *UpdateOptions) Verb() string {
+	switch o.Kind {
+	case KindUpdate:
+		return "update"
+	case KindPromotion:
+		return "promote"
+	case KindRollback:
+		return "rollback"
+	default:
+		return o.Kind
+	}
+}
+
+// DefaultMessage returns the default description of the operations intent
+// for a given phase
+func (o *UpdateOptions) DefaultMessage(phase core.Descriptor) string {
+	return fmt.Sprintf("%s %s", strings.ToTitle(o.Verb()), phase.Metadata.Name)
+}

--- a/pkg/phases/oci/oci.go
+++ b/pkg/phases/oci/oci.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/get-glu/glu/pkg/containers"
 	"github.com/get-glu/glu/pkg/core"
-	"github.com/get-glu/glu/pkg/edges"
+	"github.com/get-glu/glu/pkg/core/typed"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
@@ -15,7 +15,7 @@ import (
 
 const ANNOTATION_OCI_IMAGE_URL = "dev.getglu.oci.image.url"
 
-var _ edges.Phase[Resource] = (*Phase[Resource])(nil)
+var _ typed.Phase[Resource] = (*Phase[Resource])(nil)
 
 type Resource interface {
 	core.Resource

--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/get-glu/glu"
 	"github.com/get-glu/glu/pkg/containers"
+	"github.com/get-glu/glu/pkg/core/typed"
 	"github.com/get-glu/glu/pkg/edges"
 	srcgit "github.com/get-glu/glu/pkg/phases/git"
 	srcoci "github.com/get-glu/glu/pkg/phases/oci"
@@ -68,7 +69,7 @@ func (b *PipelineBuilder[R]) Build() error {
 }
 
 // NewPhase constructs a new phase and registers it on the resulting pipeline produced by the builder.
-func (b *PipelineBuilder[R]) NewPhase(fn func(b Builder[R]) (edges.Phase[R], error)) (next *PhaseBuilder[R]) {
+func (b *PipelineBuilder[R]) NewPhase(fn func(b Builder[R]) (typed.Phase[R], error)) (next *PhaseBuilder[R]) {
 	next = &PhaseBuilder[R]{PipelineBuilder: b}
 	if b.err != nil {
 		return
@@ -93,11 +94,11 @@ func (b *PipelineBuilder[R]) NewPhase(fn func(b Builder[R]) (edges.Phase[R], err
 // PhaseBuilder is used to chain building new phases with edges leading to the same phase.
 type PhaseBuilder[R glu.Resource] struct {
 	*PipelineBuilder[R]
-	phase edges.Phase[R]
+	phase typed.Phase[R]
 }
 
 // PromotesTo creates a new phase and an edge to this new phase from the phase built in the receiver.
-func (b *PhaseBuilder[R]) PromotesTo(fn func(b Builder[R]) (edges.UpdatablePhase[R], error), ts ...triggers.Trigger) (next *PhaseBuilder[R]) {
+func (b *PhaseBuilder[R]) PromotesTo(fn func(b Builder[R]) (typed.UpdatablePhase[R], error), ts ...triggers.Trigger) (next *PhaseBuilder[R]) {
 	next = &PhaseBuilder[R]{PipelineBuilder: b.PipelineBuilder}
 	if b.err != nil {
 		return

--- a/pkg/reflog/log.go
+++ b/pkg/reflog/log.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	ErrBucketNotFound = errors.New("bucket not found")
+	ErrNotFound = errors.New("not found")
 )
 
 type Log[R core.Resource] struct {
@@ -145,6 +145,44 @@ func (l *Log[R]) fetchLatestVersion(refs *bbolt.Bucket) (v version, _ bool) {
 	return v, true
 }
 
+// GetResourceAtVersion returns the state of the resource at a given point in history identified by the provided version
+func (l *Log[R]) GetResourceAtVersion(ctx context.Context, phase core.Descriptor, v uuid.UUID) (r R, _ error) {
+	return r, l.db.View(func(tx *bbolt.Tx) error {
+		refs, err := getRefsBucket(phase, tx)
+		if err != nil {
+			return err
+		}
+
+		versionBytes, err := v.MarshalText()
+		if err != nil {
+			return err
+		}
+
+		versionData := refs.Get(versionBytes)
+		if versionData == nil {
+			return fmt.Errorf("version %q: %w", v, ErrNotFound)
+		}
+
+		blobs, err := getBlobBucket(phase, tx)
+		if err != nil {
+			return err
+		}
+
+		var version version
+		if err := l.decoder(versionData, &version); err != nil {
+			return err
+		}
+
+		blob := blobs.Get(version.Digest)
+		if blob != nil {
+			return fmt.Errorf("version data for %q: %w", v, ErrNotFound)
+		}
+
+		return l.decoder(blob, &r)
+	})
+}
+
+// Histort returns a slice of states for a provided phase descriptor.
 func (l *Log[R]) History(ctx context.Context, phase core.Descriptor) (states []core.State, _ error) {
 	return states, l.db.View(func(tx *bbolt.Tx) error {
 		refs, err := getRefsBucket(phase, tx)
@@ -178,7 +216,6 @@ func (l *Log[R]) History(ctx context.Context, phase core.Descriptor) (states []c
 			}
 
 			timestamp := time.Unix(id.Time().UnixTime())
-
 			states = append(states, core.State{
 				Version:     id,
 				Digest:      string(version.Digest),
@@ -202,7 +239,7 @@ func getRefsBucket(phase core.Descriptor, tx *bbolt.Tx) (*bbolt.Bucket, error) {
 
 func getBucket(tx *bbolt.Tx, path ...string) (bkt *bbolt.Bucket, err error) {
 	if len(path) == 0 {
-		return nil, fmt.Errorf("empty path: %w", ErrBucketNotFound)
+		return nil, fmt.Errorf("empty path: %w", ErrNotFound)
 	}
 
 	var b interface {
@@ -211,7 +248,7 @@ func getBucket(tx *bbolt.Tx, path ...string) (bkt *bbolt.Bucket, err error) {
 
 	for i, p := range path {
 		if bkt = b.Bucket([]byte(p)); bkt == nil {
-			return nil, fmt.Errorf("bucket %q: %w", strings.Join(path[:i+1], "/"), ErrBucketNotFound)
+			return nil, fmt.Errorf("bucket %q: %w", strings.Join(path[:i+1], "/"), ErrNotFound)
 		}
 		b = bkt
 	}
@@ -220,7 +257,7 @@ func getBucket(tx *bbolt.Tx, path ...string) (bkt *bbolt.Bucket, err error) {
 
 func createBucketPath(tx *bbolt.Tx, path ...string) (bkt *bbolt.Bucket, err error) {
 	if len(path) == 0 {
-		return nil, fmt.Errorf("empty path: %w", ErrBucketNotFound)
+		return nil, fmt.Errorf("empty path: %w", ErrNotFound)
 	}
 
 	var b interface {

--- a/pkg/reflog/log.go
+++ b/pkg/reflog/log.go
@@ -174,7 +174,7 @@ func (l *Log[R]) GetResourceAtVersion(ctx context.Context, phase core.Descriptor
 		}
 
 		blob := blobs.Get(version.Digest)
-		if blob != nil {
+		if blob == nil {
 			return fmt.Errorf("version data for %q: %w", v, ErrNotFound)
 		}
 

--- a/server.go
+++ b/server.go
@@ -184,16 +184,18 @@ func (s *Server) createPipelineResponse(ctx context.Context, pipeline *core.Pipe
 }
 
 // Handler methods
+
 func (s *Server) listPipelines(w http.ResponseWriter, r *http.Request) {
 	var (
 		ctx               = r.Context()
+		slog              = slog.With("path", r.URL.Path)
 		pipelineResponses = make([]pipelineResponse, 0, len(s.system.pipelines))
 	)
 
 	for _, pipeline := range s.system.pipelines {
 		response, err := s.createPipelineResponse(ctx, pipeline)
 		if err != nil {
-			slog.Error("building pipeline response", "path", r.URL.Path, "error", err)
+			slog.Error("building pipeline response", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -204,25 +206,28 @@ func (s *Server) listPipelines(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(listPipelinesResponse{
 		Pipelines: pipelineResponses,
 	}); err != nil {
-		slog.Error("encoding pipeline", "path", r.URL.Path, "error", err)
+		slog.Error("encoding pipeline", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }
 
 func (s *Server) getPipeline(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+	var (
+		ctx  = r.Context()
+		slog = slog.With("path", r.URL.Path)
+	)
 
 	pipeline, err := s.system.GetPipeline(chi.URLParam(r, "pipeline"))
 	if err != nil {
-		slog.Debug("resource not found", "path", r.URL.Path, "error", err)
+		slog.Debug("resource not found", "error", err)
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 
 	response, err := s.createPipelineResponse(ctx, pipeline)
 	if err != nil {
-		slog.Error("building pipeline response", "path", r.URL.Path, "error", err)
+		slog.Error("building pipeline response", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -231,6 +236,8 @@ func (s *Server) getPipeline(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getPhase(w http.ResponseWriter, r *http.Request) {
+	slog := slog.With("path", r.URL.Path)
+
 	pipeline, err := s.system.GetPipeline(chi.URLParam(r, "pipeline"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -242,7 +249,7 @@ func (s *Server) getPhase(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, core.ErrNotFound) {
-			slog.Debug("resource not found", "path", r.URL.Path, "error", err)
+			slog.Debug("resource not found", "error", err)
 			status = http.StatusNotFound
 		}
 
@@ -257,16 +264,18 @@ func (s *Server) getPhase(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		slog.Error("encoding response", "path", r.URL.Path, "error", err)
+		slog.Error("encoding response", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }
 
 func (s *Server) edgePerform(w http.ResponseWriter, r *http.Request) {
+	slog := slog.With("path", r.URL.Path)
+
 	pipeline, err := s.system.GetPipeline(chi.URLParam(r, "pipeline"))
 	if err != nil {
-		slog.Debug("resource not found", "path", r.URL.Path, "error", err)
+		slog.Debug("resource not found", "error", err)
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
@@ -278,14 +287,14 @@ func (s *Server) edgePerform(w http.ResponseWriter, r *http.Request) {
 
 	outgoing, ok := pipeline.EdgesFrom()[from]
 	if !ok {
-		slog.Debug("edge not found", "path", r.URL.Path, "error", err, "from", from)
+		slog.Debug("edge not found", "path", err, "from", from)
 		http.Error(w, "edge not found", http.StatusNotFound)
 		return
 	}
 
 	edge, ok := outgoing[to]
 	if !ok {
-		slog.Debug("edge not found", "path", r.URL.Path, "error", err, "from", from, "to", to)
+		slog.Debug("edge not found", "path", err, "from", from, "to", to)
 		http.Error(w, "edge not found", http.StatusNotFound)
 		return
 	}
@@ -298,22 +307,24 @@ func (s *Server) edgePerform(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		slog.Error("performing promotion", "path", r.URL.Path, "error", err)
+		slog.Error("performing promotion", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(&result); err != nil {
-		slog.Error("encoding response", "path", r.URL.Path, "error", err)
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		slog.Error("encoding response", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }
 
 func (s *Server) phaseHistory(w http.ResponseWriter, r *http.Request) {
+	slog := slog.With("path", r.URL.Path)
+
 	pipeline, err := s.system.GetPipeline(chi.URLParam(r, "pipeline"))
 	if err != nil {
-		slog.Debug("resource not found", "path", r.URL.Path, "error", err)
+		slog.Debug("resource not found", "error", err)
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
@@ -323,7 +334,7 @@ func (s *Server) phaseHistory(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, core.ErrNotFound) {
-			slog.Debug("resource not found", "path", r.URL.Path, "error", err)
+			slog.Debug("resource not found", "error", err)
 			status = http.StatusNotFound
 		}
 
@@ -333,22 +344,24 @@ func (s *Server) phaseHistory(w http.ResponseWriter, r *http.Request) {
 
 	history, err := phase.History(r.Context())
 	if err != nil {
-		slog.Error("getting phase history", "path", r.URL.Path, "error", err)
+		slog.Error("getting phase history", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	if err := json.NewEncoder(w).Encode(history); err != nil {
-		slog.Error("encoding response", "path", r.URL.Path, "error", err)
+		slog.Error("encoding response", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }
 
 func (s *Server) phaseRollback(w http.ResponseWriter, r *http.Request) {
+	slog := slog.With("path", r.URL.Path)
+
 	pipeline, err := s.system.GetPipeline(chi.URLParam(r, "pipeline"))
 	if err != nil {
-		slog.Debug("resource not found", "path", r.URL.Path, "error", err)
+		slog.Debug("resource not found", "error", err)
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
@@ -358,7 +371,7 @@ func (s *Server) phaseRollback(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, core.ErrNotFound) {
-			slog.Debug("resource not found", "path", r.URL.Path, "error", err)
+			slog.Debug("resource not found", "error", err)
 			status = http.StatusNotFound
 		}
 
@@ -374,13 +387,20 @@ func (s *Server) phaseRollback(w http.ResponseWriter, r *http.Request) {
 
 	version, err := uuid.Parse(chi.URLParam(r, "version"))
 	if err != nil {
-		slog.Error("parsing version", "path", r.URL.Path, "error", err)
+		slog.Error("parsing version", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if err := rollback.Rollback(r.Context(), version); err != nil {
-		slog.Error("rolling back phase", "path", r.URL.Path, "error", err)
+	result, err := rollback.Rollback(r.Context(), version)
+	if err != nil {
+		slog.Error("rolling back phase", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		slog.Error("encoding response", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Supports #97

This adds the APIs and server-side functionality for rolling a phase back to a previously known version in time.

The changes introduces the new interface:

```go
type RollbackPhase interface {
    Phase
    Rollback(context.Context, uuid.UUID) error
}
```

This is an interface upgrade target which the server attempts when you try to do:
```
POST /api/v1/pipelines/{pipeline}/phases/{phase}/rollback/{version}
```

Which is the new endpoint used to rollback to a known version.
The version should first be obtained through the history endpoint.
The operation will fail if the version is no longer in history.

I am still validating it works as expected, but this is the initial implementation.
I will update this description when I have validated it.