### PR TITLE
feat: add link to github commit in history

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -5,6 +5,7 @@ cloud.google.com/go/compute/metadata v0.5.0/go.mod h1:aHnloV2TPI38yx4s9+wAZhHykW
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/cncf/xds/go v0.0.0-20240723142845-024c85f92f20/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
@@ -56,6 +57,7 @@ golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5D
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
@@ -77,6 +79,7 @@ golang.org/x/tools v0.11.0/go.mod h1:anzJrxPjNtfgiYQYirP2CPGzGLxrH2u2QBhn6Bf3qY8
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
+golang.org/x/tools v0.27.0/go.mod h1:sUi0ZgbwW9ZPAq26Ekut+weQPR5eIM6GQLQ1Yjm1H0Q=
 google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc h1:Nf+EdcTLHR8qDNN/KfkQL0u0ssxt9OhbaWCl5C0ucEI=
 google.golang.org/genproto/googleapis/api v0.0.0-20240903143218-8af14fe29dc1/go.mod h1:qpvKtACPCQhAdu3PyQgV4l3LMXZEtft7y8QcarRsp9I=
 google.golang.org/genproto/googleapis/api v0.0.0-20241118233622-e639e219e697/go.mod h1:+D9ySVjN8nY8YCVjc5O7PZDIdZporIDY3KaGfJunh88=

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -215,6 +215,10 @@ func (r *Repository) startPolling(ctx context.Context) {
 	}()
 }
 
+func (r *Repository) Remote() *config.RemoteConfig {
+	return r.remote
+}
+
 func (r *Repository) DefaultBranch() string {
 	return r.defaultBranch
 }

--- a/ui/src/components/label.tsx
+++ b/ui/src/components/label.tsx
@@ -12,7 +12,7 @@ export function Label({ labelKey, value, className }: LabelProps) {
     <Badge
       key={`${labelKey}-${value}`}
       className={cn(
-        `whitespace-nowrap rounded-md text-xs font-light ${getLabelColor(labelKey, value)}`,
+        `whitespace-nowrap rounded-md text-xs font-medium ${getLabelColor(labelKey, value)}`,
         className
       )}
     >

--- a/ui/src/components/phase-history.tsx
+++ b/ui/src/components/phase-history.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { useState } from 'react';
-import { History, MoreVertical } from 'lucide-react';
+import { Github, History, MoreVertical } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useGetPhaseHistoryQuery } from '@/services/api';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -24,6 +24,7 @@ import { Button } from './ui/button';
 import { State } from '@/types/pipeline';
 import { PhaseStateDetails } from './phase-state-details';
 import { PhaseRollbackDialog } from './phase-rollback-dialog';
+import { ANNOTATION_GIT_COMMIT_URL } from '@/types/metadata';
 
 interface PhaseHistoryProps {
   pipelineId: string;
@@ -151,33 +152,54 @@ function PhaseHistoryItem({ pipelineId, phaseId, state, index }: PhaseHistoryIte
         {/* history card */}
         <div className="ml-6 mt-2 flex justify-between">
           {/* digest and hover */}
-          <HoverCard>
-            <HoverCardTrigger asChild className="cursor-default">
-              <span className="inline-flex items-center truncate rounded-md bg-muted px-2 py-1">
-                <span className="font-mono text-xs">{state.digest?.slice(0, 30)}</span>
-              </span>
-            </HoverCardTrigger>
-            <HoverCardContent className="flex w-full flex-col gap-1">
-              <div className="text-sm">
-                <span className="text-foreground">Recorded At: </span>
-                <span className="inline-flex items-center truncate rounded-md bg-muted px-2 py-1 text-xs">
-                  {new Date(state.recorded_at).toUTCString()}
+          <div className="flex flex-col gap-2">
+            <HoverCard>
+              <HoverCardTrigger asChild className="cursor-default">
+                <span className="inline-flex items-center truncate rounded-md bg-muted px-2 py-1">
+                  <span className="font-mono text-xs">{state.digest?.slice(0, 30)}</span>
                 </span>
-              </div>
-              <div className="text-sm">
-                <span className="text-foreground">Digest: </span>
-                <span className="inline-flex items-center truncate rounded-md bg-muted px-2 py-1 font-mono text-xs">
-                  {state.digest}
-                </span>
-              </div>
-              <div className="text-sm">
-                <span className="text-foreground">Version: </span>
-                <span className="inline-flex items-center truncate rounded-md bg-muted px-2 py-1 font-mono text-xs">
-                  {state.version}
-                </span>
-              </div>
-            </HoverCardContent>
-          </HoverCard>
+              </HoverCardTrigger>
+              <HoverCardContent className="flex w-full flex-col gap-1">
+                <div className="text-sm">
+                  <span className="text-foreground">Recorded At: </span>
+                  <span className="inline-flex items-center truncate rounded-md bg-muted px-2 py-1 text-xs">
+                    {new Date(state.recorded_at).toUTCString()}
+                  </span>
+                </div>
+                <div className="text-sm">
+                  <span className="text-foreground">Digest: </span>
+                  <span className="inline-flex items-center truncate rounded-md bg-muted px-2 py-1 font-mono text-xs">
+                    {state.digest}
+                  </span>
+                </div>
+                <div className="text-sm">
+                  <span className="text-foreground">Version: </span>
+                  <span className="inline-flex items-center truncate rounded-md bg-muted px-2 py-1 font-mono text-xs">
+                    {state.version}
+                  </span>
+                </div>
+              </HoverCardContent>
+            </HoverCard>
+
+            <div className="group flex flex-row flex-wrap gap-2 hover:underline">
+              {Object.entries(state.annotations ?? {}).map(
+                ([key, value]) =>
+                  key === ANNOTATION_GIT_COMMIT_URL &&
+                  value.startsWith('https://github.com') && (
+                    <a
+                      key={`${key}-${value}`}
+                      href={value}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 px-2 py-1 text-xs"
+                    >
+                      <Github className="h-2.5 w-2.5" />
+                      Commit
+                    </a>
+                  )
+              )}
+            </div>
+          </div>
 
           {/* dropdown menu */}
           <DropdownMenu>

--- a/ui/src/components/phase-history.tsx
+++ b/ui/src/components/phase-history.tsx
@@ -182,21 +182,16 @@ function PhaseHistoryItem({ pipelineId, phaseId, state, index }: PhaseHistoryIte
             </HoverCard>
 
             <div className="group flex flex-row flex-wrap gap-2 hover:underline">
-              {Object.entries(state.annotations ?? {}).map(
-                ([key, value]) =>
-                  key === ANNOTATION_GIT_COMMIT_URL &&
-                  value.startsWith('https://github.com') && (
-                    <a
-                      key={`${key}-${value}`}
-                      href={value}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 px-2 py-1 text-xs"
-                    >
-                      <Github className="h-2.5 w-2.5" />
-                      Commit
-                    </a>
-                  )
+              {state.annotations?.[ANNOTATION_GIT_COMMIT_URL]?.startsWith('https://github.com') && (
+                <a
+                  href={state.annotations[ANNOTATION_GIT_COMMIT_URL]}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 px-2 py-1 text-xs"
+                >
+                  <Github className="h-2.5 w-2.5" />
+                  Commit
+                </a>
               )}
             </div>
           </div>

--- a/ui/src/components/phase-state-details.tsx
+++ b/ui/src/components/phase-state-details.tsx
@@ -7,6 +7,8 @@ import { Label } from '@/components/label';
 import { Button } from '@/components/ui/button';
 import { PhaseRollbackDialog } from './phase-rollback-dialog';
 import { useState } from 'react';
+import { ANNOTATION_GIT_COMMIT_URL } from '@/types/metadata';
+import { Github } from 'lucide-react';
 
 interface PhaseStateDetailsProps {
   isOpen: boolean;
@@ -71,12 +73,36 @@ export function PhaseStateDetails({
               </div>
 
               <div className="space-y-4">
+                <h3 className="text-lg font-semibold">Links</h3>
+                <div className="flex flex-row flex-wrap gap-2">
+                  {Object.entries(state.annotations ?? {}).map(
+                    ([key, value]) =>
+                      key === ANNOTATION_GIT_COMMIT_URL &&
+                      value.startsWith('https://github.com') && (
+                        <a
+                          key={`${key}-${value}`}
+                          href={value}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-sm hover:bg-muted/80"
+                        >
+                          <Github className="h-3.5 w-3.5" />
+                          Commit
+                        </a>
+                      )
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold">Annotations</h3>
-                {Object.entries(state.annotations ?? {}).map(([key, value]) => (
-                  <div key={`${key}-${value}`} className="mb-2 flex">
-                    <Label labelKey={key} value={value} />
-                  </div>
-                ))}
+                <div className="flex flex-row flex-wrap gap-2">
+                  {Object.entries(state.annotations ?? {}).map(([key, value]) => (
+                    <span key={`${key}-${value}`}>
+                      <Label labelKey={key} value={value} />
+                    </span>
+                  ))}
+                </div>
               </div>
 
               <div className="space-y-4">

--- a/ui/src/components/phase-state-details.tsx
+++ b/ui/src/components/phase-state-details.tsx
@@ -75,21 +75,18 @@ export function PhaseStateDetails({
               <div className="space-y-4">
                 <h3 className="text-lg font-semibold">Links</h3>
                 <div className="flex flex-row flex-wrap gap-2">
-                  {Object.entries(state.annotations ?? {}).map(
-                    ([key, value]) =>
-                      key === ANNOTATION_GIT_COMMIT_URL &&
-                      value.startsWith('https://github.com') && (
-                        <a
-                          key={`${key}-${value}`}
-                          href={value}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-sm hover:bg-muted/80"
-                        >
-                          <Github className="h-3.5 w-3.5" />
-                          Commit
-                        </a>
-                      )
+                  {state.annotations?.[ANNOTATION_GIT_COMMIT_URL]?.startsWith(
+                    'https://github.com'
+                  ) && (
+                    <a
+                      href={state.annotations[ANNOTATION_GIT_COMMIT_URL]}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-sm hover:bg-muted/80"
+                    >
+                      <Github className="h-3.5 w-3.5" />
+                      Commit
+                    </a>
                   )}
                 </div>
               </div>

--- a/ui/src/types/metadata.ts
+++ b/ui/src/types/metadata.ts
@@ -6,3 +6,4 @@ export type Metadata = {
 
 export const ANNOTATION_OCI_IMAGE_URL = 'dev.getglu.oci.image.url';
 export const ANNOTATION_GIT_PROPOSAL_URL = 'dev.getglu.git.proposal.url';
+export const ANNOTATION_GIT_COMMIT_URL = 'dev.getglu.git.commit.url';


### PR DESCRIPTION
Fixes: #111 

![CleanShot 2024-12-05 at 13 36 37@2x](https://github.com/user-attachments/assets/5dcb47c3-4260-4d4a-ac9d-f2ab2495e35f)
![CleanShot 2024-12-05 at 13 23 17@2x](https://github.com/user-attachments/assets/23ac1ab3-f430-429f-9d22-709fe3a8c66b)

its very hacky for now as it only supports links that start with `github.com`, but we can clean up the logic/abstract it in the future to support other SCMs