### PR TITLE
fix(triggers): continue on skipped and error conditions in schedule

### DIFF
--- a/glu.go
+++ b/glu.go
@@ -204,9 +204,8 @@ func (s *System) Run() error {
 	}
 
 	var (
-		conf  = sConf.conf
-		group *errgroup.Group
-		srv   = http.Server{
+		conf = sConf.conf
+		srv  = http.Server{
 			Addr:    fmt.Sprintf("%s:%d", conf.Server.Host, conf.Server.Port),
 			Handler: s.server,
 		}
@@ -256,8 +255,7 @@ func (s *System) Run() error {
 		}
 	}
 
-	group, ctx = errgroup.WithContext(ctx)
-
+	var group errgroup.Group
 	group.Go(func() error {
 		<-ctx.Done()
 
@@ -309,6 +307,7 @@ func (s *System) runTriggers(ctx context.Context) error {
 		for edge := range pipeline.Edges() {
 			tedge, ok := edge.(core.TriggerableEdge)
 			if !ok {
+				slog.Debug("skipping non-triggerable edge", "kind", edge.Kind())
 				continue
 			}
 

--- a/pkg/phases/git/git.go
+++ b/pkg/phases/git/git.go
@@ -208,6 +208,7 @@ func (p *Phase[R]) Notify(ctx context.Context, refs map[string]string) error {
 }
 
 func (p *Phase[R]) recordPhaseState(ctx context.Context, opts ...containers.Option[git.ViewUpdateOptions]) (err error) {
+
 	var (
 		r    = p.newFn()
 		hash plumbing.Hash

--- a/pkg/triggers/schedule/schedule.go
+++ b/pkg/triggers/schedule/schedule.go
@@ -44,12 +44,11 @@ func (t *Trigger) Run(ctx context.Context, edge core.Edge) {
 			return
 		case <-ticker.C:
 			if _, err := edge.Perform(ctx); err != nil {
-				if !errors.Is(err, edges.ErrSkipped) {
-					return
+				if errors.Is(err, edges.ErrSkipped) {
+					continue
 				}
 
 				slog.Error("triggered edge", "error", err)
-				return
 			}
 		}
 	}


### PR DESCRIPTION
I borked this in the refactor leading to promotions only happening once on startup.
This removes the returns from the schedule and lets it continue under all circumstrances apart from context cancellation.