### PR TITLE
refactor(phase/git): rework proposal process

### DIFF
--- a/pkg/scm/github/github.go
+++ b/pkg/scm/github/github.go
@@ -128,7 +128,7 @@ func (s *SCM) CloseProposal(ctx context.Context, proposal *git.Proposal) error {
 		return err
 	}
 
-	slog.Info("proposal updated", "scm_type", "github", "proposal_url", pr.GetHTMLURL())
+	slog.Info("proposal closed", "scm_type", "github", "proposal_url", pr.GetHTMLURL())
 
 	proposal.BaseRevision = pr.Base.GetSHA()
 	proposal.HeadRevision = pr.Head.GetSHA()


### PR DESCRIPTION
This change does a number of things for the PR / proposal lifecycle:

1. It caches previously fetched / created proposals on the Phase itself.

This avoids us doing more costly paginated walks to locate previously created open PRs associated with the phase on each attempt to promote.

2. It adjust the flow to close existing PRs

When a new version is observed and an existing PR is open, then the update code will close the existing PR first, then push to the new branch and open a new PR. It adds a comment to the old PR linking to the new one for clarity.

<img width="1017" alt="Screenshot 2024-12-10 at 17 44 55" src="https://github.com/user-attachments/assets/a82d67d1-9f68-4d63-8b47-5c1b1277efbd">

Here is what the robots say:

This pull request includes significant changes to the `internal/git/repository.go` and `pkg/phases/git/git.go` files, focusing on refactoring and enhancing the branch and proposal handling mechanisms. The changes include renaming types, adding new options, and improving the proposal management logic.

### Refactoring and Enhancements:

* `internal/git/repository.go`:
  - Renamed `ViewUpdateOptions` to `BranchOptions` and added new fields such as `base` and `pushIfEmpty`.
  - Updated methods to use `BranchOptions` instead of `ViewUpdateOptions`.
  - Added logic to handle empty commits and the `pushIfEmpty` option in `UpdateAndPush`.
  - Refactored `CreateBranchIfNotExists` to use `BranchOptions`. [[1]](diffhunk://#diff-71927d0ab1fb559addb55b9aa201c0e7e17b6ef1da184529792b7fe5919844feL537-R566) [[2]](diffhunk://#diff-71927d0ab1fb559addb55b9aa201c0e7e17b6ef1da184529792b7fe5919844feL562-R581)

* `pkg/phases/git/git.go`:
  - Removed `AnnotationProposalNumberKey` and added new methods to the `Proposer` interface such as `IsProposalOpen` and `CommentProposal`. [[1]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9L28) [[2]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9R49-R60)
  - Added `currentProposal` field to the `Phase` struct and updated its initialization. [[1]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9R79-R84) [[2]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9R152-R156)
  - Refactored `Update` and `propose` methods to improve proposal handling and branch management. [[1]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9L279-R294) [[2]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9L304-R318) [[3]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9L326-R364) [[4]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9R376-R398) [[5]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9R418) [[6]](diffhunk://#diff-3a432f2e994eb45ef36ca83dc5929bfe0ff2ca7aa55def4b43231e37aa7ae8c9L407-R462)

### Proposal Management:

* `pkg/scm/github/github.go`:
  - Added `ID` and `URL` fields to the `Proposal` struct and updated `GetCurrentProposal` to populate these fields.
  - Implemented `IsProposalOpen` method to check if a proposal is still open.

### Logging Improvements:

* `pkg/phases/logger/logger.go`:
  - Simplified the `PhaseLogger` by removing the `last` field and updating methods to fetch the latest version directly from the database. [[1]](diffhunk://#diff-1568c4e936c79c5ec54e626ab5cee378d9997ca9e9d3bf3c427dce4e0ed35006L34-L42) [[2]](diffhunk://#diff-1568c4e936c79c5ec54e626ab5cee378d9997ca9e9d3bf3c427dce4e0ed35006L133-R131) [[3]](diffhunk://#diff-1568c4e936c79c5ec54e626ab5cee378d9997ca9e9d3bf3c427dce4e0ed35006L150-R148) [[4]](diffhunk://#diff-1568c4e936c79c5ec54e626ab5cee378d9997ca9e9d3bf3c427dce4e0ed35006L206-R204)