### PR TITLE
chore: support pulling with plain http in k8s receiver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /glu.yaml
-bin
-./clickhouse/
+/bin
+/clickhouse

--- a/collector.yaml
+++ b/collector.yaml
@@ -3,6 +3,7 @@ receivers:
     endpoint: 0.0.0.0:3000
   k8s:
     cluster_name: "staging"
+    plain_http: true
   otlp:
     protocols:
       http:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -187,6 +187,14 @@ func TestConfig(t *testing.T) {
 					Enabled:  true,
 					Exporter: MetricsExporterPrometheus,
 				},
+				Storage: Storage{
+					Type: "clickhouse",
+					ClickHouse: &StorageClickHouse{
+						Address:  "127.0.0.1:9000",
+						Database: "default",
+						Username: "default",
+					},
+				},
 			},
 		},
 	}

--- a/otel/receiver/k8sreceiver/factory.go
+++ b/otel/receiver/k8sreceiver/factory.go
@@ -30,6 +30,7 @@ const (
 type Config struct {
 	ClusterName string   `mapstructure:"cluster_name"`
 	AuthType    AuthType `mapstructure:"auth_type"`
+	PlainHTTP   bool     `mapstructure:"plain_http"`
 }
 
 func (cfg *Config) Validate() error {
@@ -42,7 +43,8 @@ func (cfg *Config) Validate() error {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		AuthType: AuthTypeKubeConfig,
+		AuthType:  AuthTypeKubeConfig,
+		PlainHTTP: false,
 	}
 }
 

--- a/otel/receiver/k8sreceiver/oci.go
+++ b/otel/receiver/k8sreceiver/oci.go
@@ -10,11 +10,28 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 )
 
-func fetchOCIAttributes(ctx context.Context, ref string) (map[string]string, error) {
+type ociOptions struct {
+	PlainHTTP bool
+}
+
+type ociOptionsFunc func(opts *ociOptions)
+
+func WithPlainHTTP(opts *ociOptions) {
+	opts.PlainHTTP = true
+}
+
+func fetchOCIAttributes(ctx context.Context, ref string, opts ...ociOptionsFunc) (map[string]string, error) {
 	repo, err := remote.NewRepository(ref)
 	if err != nil {
 		return nil, err
 	}
+
+	ociOpts := &ociOptions{}
+	for _, opt := range opts {
+		opt(ociOpts)
+	}
+
+	repo.PlainHTTP = ociOpts.PlainHTTP
 
 	desc, reader, err := repo.FetchReference(ctx, ref)
 	if err != nil {

--- a/otel/receiver/k8sreceiver/receiver.go
+++ b/otel/receiver/k8sreceiver/receiver.go
@@ -186,7 +186,12 @@ func (k *k8sReceiver) onUpdatePod(oldP, newP *corev1.Pod) {
 			existing.digest = status.ImageID
 			k.states.Store(key, existing)
 
-			ociAttrs, err := fetchOCIAttributes(k.ctx, status.ImageID)
+			ociOpts := []ociOptionsFunc{}
+			if k.cfg.PlainHTTP {
+				ociOpts = append(ociOpts, WithPlainHTTP)
+			}
+
+			ociAttrs, err := fetchOCIAttributes(k.ctx, status.ImageID, ociOpts...)
 			if err != nil {
 				logger.Warn("Error fetching OCI attributes", zap.Error(err))
 				// here we simply leave the map as unassigned so that it


### PR DESCRIPTION
support pulling using plain HTTP from oci repos