### PR TITLE
feat(ui): add status section to phase node and panel

### DIFF
--- a/ui/src/components/phase-node.tsx
+++ b/ui/src/components/phase-node.tsx
@@ -45,6 +45,20 @@ const PhaseNode = ({ data: phase }: NodeProps<PhaseNodeType>) => {
             ))}
       </div>
 
+      {phase.status && Object.keys(phase.status).length > 0 && (
+        <div className="mt-4 flex w-full flex-wrap border border-muted p-2">
+          <div className="relative -top-[22px] left-0 w-0">
+            <span className="text-xs">status:</span>
+          </div>
+          {Object.entries(phase.status).map(([key, value]) => (
+            <div key={`status-${key}-${value}`} className="mt-2 flex text-xs">
+              <span className="mr-2 text-muted-foreground">{key}: </span>
+              <span className="max-w-[150px] overflow-x-scroll whitespace-nowrap">{value}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
       <Handle type="target" position={Position.Left} style={{ left: -8 }} />
     </div>
   );

--- a/ui/src/components/phase-panel.tsx
+++ b/ui/src/components/phase-panel.tsx
@@ -13,7 +13,7 @@ interface PhasePanelProps {
 }
 
 export function PhasePanel({ node, isExpanded, onToggle }: PhasePanelProps) {
-  const descriptor = node.data.descriptor;
+  const { descriptor, status } = node.data;
   const Icon = getSourceIcon(descriptor.source);
 
   return (
@@ -30,7 +30,7 @@ export function PhasePanel({ node, isExpanded, onToggle }: PhasePanelProps) {
 
       <div
         className={cn(
-          'grid grid-cols-2 gap-4 overflow-hidden transition-[max-height,opacity] duration-300 ease-in-out',
+          'grid grid-cols-2 grid-rows-2 overflow-hidden transition-[max-height,opacity] duration-300 ease-in-out',
           isExpanded ? 'max-h-[200px] opacity-100' : 'max-h-0 opacity-0'
         )}
       >
@@ -44,7 +44,7 @@ export function PhasePanel({ node, isExpanded, onToggle }: PhasePanelProps) {
           </div>
         </div>
 
-        <div className="h-[200px] p-4">
+        <div className="h-[150px] p-4">
           {descriptor.metadata.labels && Object.keys(descriptor.metadata.labels).length > 0 && (
             <>
               <h3 className="text-sm font-medium">Labels</h3>
@@ -53,6 +53,28 @@ export function PhasePanel({ node, isExpanded, onToggle }: PhasePanelProps) {
                   {Object.entries(descriptor.metadata.labels).map(([key, value]) => (
                     <Label key={key} labelKey={key} value={value} className="cursor-default" />
                   ))}
+                </div>
+              </ScrollArea>
+            </>
+          )}
+        </div>
+
+        <div className="h-[150px] p-4">
+          {status && Object.keys(status).length > 0 && (
+            <>
+              <h3 className="text-sm font-medium">Status</h3>
+              <ScrollArea className="mt-2 h-[150px]">
+                <div className="mt-2">
+                  <div className="text-sm">
+                    {Object.entries(status).map(([key, value]) => (
+                      <div key={key} className="mt-2 block">
+                        <span className="mr-2 inline-block text-muted-foreground">{key}: </span>
+                        <span className="inline-block max-w-[600px] overflow-x-clip whitespace-nowrap">
+                          {value}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </ScrollArea>
             </>

--- a/ui/src/components/pipeline.tsx
+++ b/ui/src/components/pipeline.tsx
@@ -158,7 +158,8 @@ function getElements(pipeline: PipelineType): FlowPipeline {
       type: 'phase',
       position: { x: 0, y: 0 },
       data: {
-        descriptor: phase.descriptor
+        descriptor: phase.descriptor,
+        status: phase.status
       },
       extent: 'parent'
     };


### PR DESCRIPTION
<img width="1466" alt="Screenshot 2025-01-21 at 13 17 00" src="https://github.com/user-attachments/assets/668f5216-2d6d-4e54-9b70-25e79341fe21" />

This adds status sections to the UI phase node and panel sections.